### PR TITLE
Add CourseHook that calls url and SubmissionContentResource to API

### DIFF
--- a/api_urls.py
+++ b/api_urls.py
@@ -3,8 +3,8 @@ from tastypie.api import Api
 from course.api import CourseResource, CourseInstanceResource
 from userprofile.api import UserProfileResource
 from course.api import CourseInstanceSummaryResource
-from exercise.api import ExerciseResource, CourseModuleResource, SubmissionResource, \
-    LearningObjectResource
+from exercise.api import ExerciseResource, CourseModuleResource, \
+  SubmissionResource, SubmissionContentResource, LearningObjectResource
 
 api = Api(api_name='v1')
 api.register(CourseResource())
@@ -13,6 +13,7 @@ api.register(UserProfileResource())
 api.register(ExerciseResource())
 api.register(CourseModuleResource())
 api.register(SubmissionResource())
+api.register(SubmissionContentResource())
 api.register(LearningObjectResource())
 api.register(CourseInstanceSummaryResource())
 

--- a/course/admin.py
+++ b/course/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from course.models import Course, CourseInstance
+from course.models import Course, CourseInstance, CourseHook
 from django.db.models import Q
 
 class CourseAdmin(admin.ModelAdmin):
@@ -57,3 +57,4 @@ class CourseInstanceAdmin(admin.ModelAdmin):
 
 admin.site.register(Course, CourseAdmin)
 admin.site.register(CourseInstance, CourseInstanceAdmin)
+admin.site.register(CourseHook)

--- a/course/migrations/0005_auto__add_coursehook.py
+++ b/course/migrations/0005_auto__add_coursehook.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'CourseHook'
+        db.create_table('course_coursehook', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('hook_url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+            ('hook_type', self.gf('django.db.models.fields.CharField')(default='post-grading', max_length=12)),
+            ('course_instance', self.gf('django.db.models.fields.related.ForeignKey')(related_name='course_hook', to=orm['course.CourseInstance'])),
+        ))
+        db.send_create_signal('course', ['CourseHook'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'CourseHook'
+        db.delete_table('course_coursehook')
+
+
+    models = {
+        'apps.baseplugin': {
+            'Meta': {'object_name': 'BasePlugin'},
+            'container_pk': ('django.db.models.fields.TextField', [], {}),
+            'container_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'modelwithinheritance_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['inheritance.ModelWithInheritance']", 'unique': 'True', 'primary_key': 'True'}),
+            'oauth_consumer': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['oauth_provider.Consumer']", 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'views': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'apps.basetab': {
+            'Meta': {'ordering': "['order', 'id']", 'object_name': 'BaseTab'},
+            'container_pk': ('django.db.models.fields.TextField', [], {}),
+            'container_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '12'}),
+            'modelwithinheritance_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['inheritance.ModelWithInheritance']", 'unique': 'True', 'primary_key': 'True'}),
+            'oauth_consumer': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['oauth_provider.Consumer']", 'null': 'True', 'blank': 'True'}),
+            'opening_method': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'course.course': {
+            'Meta': {'object_name': 'Course'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'teachers': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'teaching_courses'", 'blank': 'True', 'to': "orm['userprofile.UserProfile']"}),
+            'url': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'course.coursehook': {
+            'Meta': {'object_name': 'CourseHook'},
+            'course_instance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'course_hook'", 'to': "orm['course.CourseInstance']"}),
+            'hook_type': ('django.db.models.fields.CharField', [], {'default': "'post-grading'", 'max_length': '12'}),
+            'hook_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'course.courseinstance': {
+            'Meta': {'unique_together': "(('course', 'url'),)", 'object_name': 'CourseInstance'},
+            'assistants': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'assisting_courses'", 'blank': 'True', 'to': "orm['userprofile.UserProfile']"}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'instances'", 'to': "orm['course.Course']"}),
+            'ending_time': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'starting_time': ('django.db.models.fields.DateTimeField', [], {}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visible_to_students': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'inheritance.modelwithinheritance': {
+            'Meta': {'object_name': 'ModelWithInheritance'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'oauth_provider.consumer': {
+            'Meta': {'object_name': 'Consumer'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'secret': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '1'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'userprofile.userprofile': {
+            'Meta': {'ordering': "['id']", 'object_name': 'UserProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lang': ('django.db.models.fields.CharField', [], {'default': "'en_US'", 'max_length': '5'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['course']

--- a/course/migrations/0005_auto__add_coursehook.py
+++ b/course/migrations/0005_auto__add_coursehook.py
@@ -13,7 +13,7 @@ class Migration(SchemaMigration):
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('hook_url', self.gf('django.db.models.fields.URLField')(max_length=200)),
             ('hook_type', self.gf('django.db.models.fields.CharField')(default='post-grading', max_length=12)),
-            ('course_instance', self.gf('django.db.models.fields.related.ForeignKey')(related_name='course_hook', to=orm['course.CourseInstance'])),
+            ('course_instance', self.gf('django.db.models.fields.related.ForeignKey')(related_name='course_hooks', to=orm['course.CourseInstance'])),
         ))
         db.send_create_signal('course', ['CourseHook'])
 
@@ -90,7 +90,7 @@ class Migration(SchemaMigration):
         },
         'course.coursehook': {
             'Meta': {'object_name': 'CourseHook'},
-            'course_instance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'course_hook'", 'to': "orm['course.CourseInstance']"}),
+            'course_instance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'course_hooks'", 'to': "orm['course.CourseInstance']"}),
             'hook_type': ('django.db.models.fields.CharField', [], {'default': "'post-grading'", 'max_length': '12'}),
             'hook_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})

--- a/course/models.py
+++ b/course/models.py
@@ -233,7 +233,7 @@ class CourseHook(models.Model):
         try:
             res = urllib2.urlopen(self.hook_url,
                 urllib.urlencode(data), timeout=10)
-            logger.info('%s postend to %s on %s with %s',
+            logger.info("%s posted to %s on %s with %s",
                 self.hook_type, self.hook_url, self.course_instance, data
                 )
         except:

--- a/course/models.py
+++ b/course/models.py
@@ -225,7 +225,7 @@ class CourseHook(models.Model):
         choices=HOOK_CHOICES,
         default="post-grading")
     course_instance = models.ForeignKey(CourseInstance,
-        related_name="course_hook")
+        related_name="course_hooks")
 
 
     def trigger(self, data):

--- a/doc/example_grader.py
+++ b/doc/example_grader.py
@@ -68,7 +68,7 @@ class ExerciseGrader(SimpleHTTPServer.SimpleHTTPRequestHandler):
             self.wfile.write(response)
 
         # Attachment exercise. Note that the file is only stored in A+
-        if '/attachment_exercise/' in self.path:
+        elif '/attachment_exercise/' in self.path:
             response = '<html><head>\n' +\
                        '<meta name="points" value="0" />\n' +\
                        '<meta name="max-points" value="100" />\n' +\
@@ -84,7 +84,7 @@ class ExerciseGrader(SimpleHTTPServer.SimpleHTTPRequestHandler):
         # AJAX exercise
         # NOTE: The AJAX request comes from the user's browser, not A+
         #       We will now send the score to A+ using the submission URL
-        if '/ajax_exercise/' in self.path:
+        elif '/ajax_exercise/' in self.path:
             points = post_data['points'][0]
             max_points = post_data['max_points'][0]
             submission_url = parse_qs(self.path.split('?')[1])['submission_url'][0]
@@ -105,6 +105,12 @@ class ExerciseGrader(SimpleHTTPServer.SimpleHTTPRequestHandler):
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
             self.wfile.write(response)
+
+        # Demonstrating hook functionality
+        elif "/hook/" in self.path:
+            print "POST Hook detected!", self.path
+            print "Data:", post_data
+            self.send_response(200)
 
 httpd = SocketServer.TCPServer(('', PORT), ExerciseGrader)
 print 'Serving at port:', PORT

--- a/doc/initial_data.json
+++ b/doc/initial_data.json
@@ -26,6 +26,32 @@
     }
   },
   {
+    "pk": 2,
+    "model": "exercise.coursemodule",
+    "fields": {
+      "name": "Exercises with Hook",
+      "introduction": "",
+      "late_submission_deadline": "2025-09-27 10:47:09",
+      "late_submissions_allowed": false,
+      "course_instance": 2,
+      "points_to_pass": 0,
+      "closing_time": "2024-09-27 10:47:09",
+      "opening_time": "2013-09-27 10:47:09",
+      "late_submission_penalty": 0.5
+    }
+  },
+  {
+    "pk": 2,
+    "model": "exercise.learningobjectcategory",
+    "fields": {
+      "hidden_to": [],
+      "points_to_pass": 0,
+      "course_instance": 2,
+      "name": "Online Exercises with Hooks",
+      "description": ""
+    }
+  },
+  {
     "pk": 1,
     "model": "exercise.learningobject",
     "fields": {
@@ -101,6 +127,31 @@
     }
   },
   {
+    "pk": 4,
+    "model": "exercise.learningobject",
+    "fields": {
+      "category": 2,
+      "description": "",
+      "name": "First exercise: Hello A+",
+      "course_module": 2,
+      "service_url": "http://localhost:8888/first_exercise/",
+      "order": 1,
+      "instructions": ""
+    }
+  },
+  {
+    "pk": 4,
+    "model": "exercise.baseexercise",
+    "fields": {
+      "allow_assistant_grading": false,
+      "max_points": 100,
+      "points_to_pass": 40,
+      "min_group_size": 1,
+      "max_submissions": 10,
+      "max_group_size": 1
+    }
+  },
+  {
     "pk": 1,
     "model": "course.course",
     "fields": {
@@ -118,9 +169,23 @@
     "fields": {
       "website": "http://plus.cs.hut.fi/",
       "ending_time": "2024-09-27 10:47:18",
-      "url": "asdfsa",
+      "url": "basic_instance",
       "starting_time": "2013-09-27 10:47:17",
       "instance_name": "A+ Test Course Instance",
+      "course": 1,
+      "assistants": [],
+      "visible_to_students": true
+    }
+  },
+  {
+    "pk": 2,
+    "model": "course.courseinstance",
+    "fields": {
+      "website": "http://plus.cs.hut.fi/",
+      "ending_time": "2024-09-27 10:47:18",
+      "url": "hook_instance",
+      "starting_time": "2013-09-27 10:47:17",
+      "instance_name": "Hook Example",
       "course": 1,
       "assistants": [],
       "visible_to_students": true
@@ -130,21 +195,37 @@
     "pk": 1,
     "model": "inheritance.modelwithinheritance",
     "fields": {
-      "content_type": 20
+      "content_type": ["exercise", "baseexercise"]
     }
   },
   {
     "pk": 2,
     "model": "inheritance.modelwithinheritance",
     "fields": {
-      "content_type": 20
+      "content_type": ["exercise", "baseexercise"]
     }
   },
   {
     "pk": 3,
     "model": "inheritance.modelwithinheritance",
     "fields": {
-      "content_type": 20
+      "content_type": ["exercise", "baseexercise"]
+    }
+  },
+  {
+    "pk": 4,
+    "model": "inheritance.modelwithinheritance",
+    "fields": {
+      "content_type": ["exercise", "baseexercise"]
+    }
+  },
+  {
+    "pk": 1,
+    "model": "course.coursehook",
+    "fields": {
+      "hook_type": "post-grading",
+      "hook_url": "http://localhost:8888/hook/",
+      "course_instance": 2
     }
   }
 ]

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -212,6 +212,8 @@ class Submission(models.Model):
     def set_ready(self):
         self.grading_time = datetime.now()
         self._set_status("ready")
+        for hook in self.exercise.course_instance.course_hook.filter(hook_type="post-grading"):
+            hook.trigger({"submission_id":self.id})
 
     def set_error(self):
         self._set_status("error")

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -212,7 +212,7 @@ class Submission(models.Model):
     def set_ready(self):
         self.grading_time = datetime.now()
         self._set_status("ready")
-        for hook in self.exercise.course_instance.course_hook.filter(hook_type="post-grading"):
+        for hook in self.exercise.course_instance.course_hooks.filter(hook_type="post-grading"):
             hook.trigger({"submission_id":self.id})
 
     def set_error(self):


### PR DESCRIPTION
CONTAINS SCHEMAMIGRATIONS!

Adds CourseHook that enables calls to URLs after a submission is
set as ready on a specific course instance.

SubmissionContentResource is an API resource that displays the
contents of the submitted files (if there are any) base64 encoded,
as well as, students ids.

Together these can be used to automate certaing tasks with external
services, e.g. plagiarism detection.