### PR TITLE
Make exercise buttons narrower if there is a lot of exercises

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -303,6 +303,10 @@ ul.exercise_rounds li.exercise_round div.exercise-icons .btn-group .btn {
     padding: 4px 10px;
 }
 
+ul.exercise_rounds li.exercise_round div.exercise-icons-tight .btn-group .btn {
+    padding: 4px 5px;
+}
+
 ul.exercise_rounds li.open {
     border-left-color: #0088CC;
     border-left-width: 3px;

--- a/templates/course/view_instance.html
+++ b/templates/course/view_instance.html
@@ -32,7 +32,13 @@
         {% for course_module, round_summary, uncategorized_exercise_level, category_level in exercise_tree %}
             <li class="exercise_round {{ course_module|course_module_classes }}">
                 {% if course_module.is_after_open or is_teacher or is_assistant %}
+
+               {% if uncategorized_exercise_level|length <= 10 %}
                 <div class="exercise-icons">
+               {% else %}
+                <div class="exercise-icons exercise-icons-tight">
+               {% endif %}
+
                     <div class="btn-group">
                     {% for exercise, exercise_summary in uncategorized_exercise_level %}
                         <a href="{{ exercise_summary.exercise.get_absolute_url }}"


### PR DESCRIPTION
With this modification, the exercise buttons in the main view are narrower if there are more than 10 exercises in one exercise round. This prevents some layout issues.