### PR TITLE
Hotfix problem that occurs when user has no email field set in Shibboleth

### DIFF
--- a/django_shibboleth/views.py
+++ b/django_shibboleth/views.py
@@ -62,7 +62,8 @@ def shib_register(request, RegisterForm=BaseRegisterForm, register_template_name
     try:
         user.first_name = attr[settings.SHIB_FIRST_NAME]
         user.last_name = attr[settings.SHIB_LAST_NAME]
-        user.email = attr[settings.SHIB_EMAIL]
+        # In some cases, user might have Shibboleth names set but no email
+        user.email = attr.get(settings.SHIB_EMAIL, 'no-email@noemail.local')
     except:
         pass
     user.save()


### PR DESCRIPTION
Fixes a problem where A+ fails when user has no email set in Shibboleth
attributes. These cases occur at least when students have study rights for
individual courses (erillisopinto-oikeus).