### PR TITLE
Emphasize categories better

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -225,3 +225,9 @@ html, body {
 .form-inline .form-group div {
     display: inline-block;
 }
+
+/* results table */
+
+table.results-table .category-row {
+    font-weight: bold;
+}

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -71,7 +71,7 @@
     {% endif %}
   </div>
   {% if course_module.status == 'ready' %}
-  <table class="table table-striped table-condensed">
+  <table class="table table-striped table-condensed results-table">
     <tbody>
       {% for category, categorized_exercise_level in category_level %}
       <tr class="category-row" data-category="{{ category.id }}">


### PR DESCRIPTION
Emphasizes the categories better in cases when there are multiple categories. See the image.

![aplus-emphasize](https://cloud.githubusercontent.com/assets/2797729/12972235/237a0c6a-d0ac-11e5-97d2-7c2c7b4280b8.png)
