### PR TITLE
Prevent copying line numbers in code preview

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -41,6 +41,12 @@ table.src tr td.src {
 #exercise blockquote {
   font-size:100%;
 }
+.unselectable {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
 /* site footer */
 html, body {

--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -52,7 +52,7 @@ $(function() {
                     var lines = text.html().split(/\r\n|\r|\n/g);
                     var list = $("<table/>").addClass("src");
                     for (var i = 1; i <= lines.length; i++) {
-                        list.append('<tr><td class="num">' + i + '</td><td class="src">' + lines[i - 1] + '</td></tr>');
+                        list.append('<tr><td class="num unselectable">' + i + '</td><td class="src">' + lines[i - 1] + '</td></tr>');
                     }
                     text.html(list);
 


### PR DESCRIPTION
When viewing a submission in staff view in the modal panel, copying the code copies also the line numbers. This small tweak prevents this.

The CSS is based on a example in https://developer.mozilla.org/en-US/docs/Web/CSS/user-select