### PR TITLE
Fix local settings import

### DIFF
--- a/a-plus/settings.py
+++ b/a-plus/settings.py
@@ -3,7 +3,7 @@
 # local_settings.py to override any settings like
 # SECRET_KEY, DEBUG and DATABASES.
 ##
-import os
+import os, warnings
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Critical (override in local_settings.py)
@@ -285,8 +285,9 @@ LOGGING = {
 
 # Overrides and appends settings defined in local_settings.py
 try:
-    from local_settings import *
-except ImportError:
+    from .local_settings import *
+except ImportError as e:
+    warnings.warn("Couldn't find local settings: %s" % (e,))
     pass
 
 INSTALLED_APPS = INSTALLED_LOGIN_APPS + INSTALLED_APPS


### PR DESCRIPTION
Local settings were never imported (unless in path). Please check that this doesn't break any production setups.

In the future, warning will be logged if no local settings file is found