### PR TITLE
Feature: api courses resource

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -1,14 +1,29 @@
+from django.conf import settings
 from django.conf.urls import url, include
-from rest_framework.routers import DefaultRouter
+from rest_framework_extensions.routers import ExtendedDefaultRouter
 
-import userprofile.api.views
+import userprofile.api.views, \
+       course.api.views
 from exercise.api.views import *
 
-api_router = DefaultRouter()
-api_router.register(r'users', userprofile.api.views.UserViewSet, base_name='user')
+api = ExtendedDefaultRouter()
+
+api.register(r'users',
+             userprofile.api.views.UserViewSet,
+             base_name='user')
+
+with api.register(r'courses',
+                  course.api.views.CourseViewSet,
+                  base_name='course') as courses:
+    courses.register(r'exercises',
+                     course.api.views.CourseExercisesViewSet,
+                     base_name='course-exercises')
+    courses.register(r'students',
+                     course.api.views.CourseStudentsViewSet,
+                     base_name='course-students')
 
 urlpatterns = [
-    url(r'^', include(api_router.urls, namespace='api')),
+    url(r'^', include(api.urls, namespace='api')),
     url(r'^learningobject/$', LearningObjectList.as_view()),
     url(r'^submission/$', SubmissionList.as_view()),
 
@@ -16,3 +31,8 @@ urlpatterns = [
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
 ]
+
+if settings.DEBUG:
+    print(" API URLS:")
+    for url in api.urls:
+        print("  - %r" % (url,))

--- a/course/api/serializers.py
+++ b/course/api/serializers.py
@@ -1,0 +1,84 @@
+from rest_framework import serializers
+from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
+from lib.api import HtmlViewField
+
+from userprofile.api.serializers import UserBriefSerialiser
+
+from ..models import (
+    CourseInstance,
+    CourseModule,
+)
+from exercise.models import BaseExercise
+
+
+class LearningObjectSerializer(serializers.HyperlinkedModelSerializer):
+    html_url = HtmlViewField()
+    display_name = serializers.CharField(source='__str__')
+
+    class Meta:
+        model = BaseExercise
+        fields = (
+            'html_url',
+            'display_name',
+            'is_submittable',
+        )
+
+
+class CourseModuleSerializer(serializers.HyperlinkedModelSerializer):
+    url = NestedHyperlinkedIdentityField(view_name='api:course-exercises-detail', format='html')
+    html_url = HtmlViewField()
+    exercises = serializers.SerializerMethodField()
+    display_name = serializers.CharField(source='__str__')
+
+    class Meta:
+        model = CourseModule
+        fields = (
+            'url',
+            'html_url',
+            'display_name',
+            'exercises',
+            'is_open',
+        )
+
+    def get_exercises(self, obj):
+        exercises = obj.flat_learning_objects(with_sub_markers=False)
+        exercises = (e.as_leaf_class() for e in exercises)
+        serializer = LearningObjectSerializer(instance=exercises, many=True, context=self.context)
+        return serializer.data
+
+
+class CourseBriefSerializer(serializers.HyperlinkedModelSerializer):
+    """
+    ...
+    """
+    url = NestedHyperlinkedIdentityField(view_name='api:course-detail', format='html')
+    html_url = HtmlViewField()
+    course_id = serializers.IntegerField(source='id')
+    course_code = serializers.CharField(source='course.code')
+    course_name = serializers.CharField(source='course.name')
+
+    class Meta:
+        model = CourseInstance
+        fields = (
+            'url',
+            'html_url',
+            'course_id',
+            'course_code',
+            'course_name',
+            'instance_name',
+        )
+
+class CourseSerializer(CourseBriefSerializer):
+    """
+    ...
+    """
+    exercises = NestedHyperlinkedIdentityField(view_name='api:course-exercises-list', format='html')
+    students = NestedHyperlinkedIdentityField(view_name='api:course-students-list', format='html')
+
+    class Meta(CourseBriefSerializer.Meta):
+        fields = CourseBriefSerializer.Meta.fields + (
+            'starting_time',
+            'ending_time',
+            'exercises',
+            'students',
+        )

--- a/course/api/views.py
+++ b/course/api/views.py
@@ -1,0 +1,41 @@
+from rest_framework import generics, permissions, viewsets
+from rest_framework.decorators import detail_route
+from rest_framework.response import Response
+from rest_framework_extensions.mixins import NestedViewSetMixin
+from lib.api import ListSerializerMixin
+
+from ..models import (
+    CourseInstance,
+    CourseModule,
+)
+from .serializers import (
+    CourseBriefSerializer,
+    CourseSerializer,
+    CourseModuleSerializer,
+)
+from userprofile.models import UserProfile
+from userprofile.api.serializers import UserBriefSerialiser
+
+
+class CourseViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
+    queryset = CourseInstance.objects.filter(visible_to_students=True)
+    permission_classes = [permissions.IsAuthenticated]
+    lookup_url_kwarg = 'course_id'
+    listserializer_class = CourseBriefSerializer
+    serializer_class = CourseSerializer
+
+
+class CourseExercisesViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    permission_classes = [permissions.IsAuthenticated]
+    lookup_url_kwarg = 'exercisemodule_id'
+    serializer_class = CourseModuleSerializer
+    queryset = CourseModule.objects.all()
+    parent_lookup_map = {'course_id': 'course_instance.id'}
+
+
+class CourseStudentsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    permission_classes = [permissions.IsAuthenticated]
+    lookup_url_kwarg = 'user_id'
+    serializer_class = UserBriefSerialiser
+    queryset = UserProfile.objects.all()
+    parent_lookup_map = {'course_id': 'enrolled.id'}

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -128,6 +128,7 @@ class LearningObject(UrlMixin, ModelWithInheritance):
     def course_instance(self):
         return self.course_module.course_instance
 
+    @property
     def is_submittable(self):
         return False
 
@@ -247,6 +248,7 @@ class BaseExercise(LearningObject):
                 'points_to_pass':_("Points to pass cannot be greater than max_points.")
             })
 
+    @property
     def is_submittable(self):
         return True
 

--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -31,7 +31,7 @@ class ListSubmissionsView(ExerciseBaseView):
 
     def get_common_objects(self):
         super().get_common_objects()
-        if not self.exercise.is_submittable():
+        if not self.exercise.is_submittable:
             raise Http404()
         self.submissions = self.exercise.submissions\
             .defer("feedback", "assistant_feedback",

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -56,7 +56,7 @@ class ExerciseView(BaseRedirectMixin, ExerciseBaseView):
 
     def get(self, request, *args, **kwargs):
         students = self.get_students()
-        if self.exercise.is_submittable():
+        if self.exercise.is_submittable:
             self.submission_check(students)
             self.get_after_new_submission()
 
@@ -86,7 +86,7 @@ class ExerciseView(BaseRedirectMixin, ExerciseBaseView):
     def post(self, request, *args, **kwargs):
         # Stop submit trials for e.g. chapters.
         # However, allow posts from exercises switched to maintenance status.
-        if not self.exercise.is_submittable():
+        if not self.exercise.is_submittable:
             return self.http_method_not_allowed(request, *args, **kwargs)
 
         students = self.get_students()

--- a/lib/api.py
+++ b/lib/api.py
@@ -95,3 +95,10 @@ class APlusContentNegotiation(DefaultContentNegotiation):
                 accept = str(mt)
             accepts.append(accept)
         return accepts
+
+
+class ListSerializerMixin(object):
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return getattr(self, 'listserializer_class', self.serializer_class)
+        return super(ListSerializerMixin, self).get_serializer_class()

--- a/lib/api.py
+++ b/lib/api.py
@@ -1,6 +1,6 @@
 from distutils.version import LooseVersion as _version
 
-from rest_framework import exceptions
+from rest_framework import exceptions, serializers
 from rest_framework.renderers import JSONRenderer
 from rest_framework.versioning import AcceptHeaderVersioning, URLPathVersioning
 from rest_framework.negotiation import DefaultContentNegotiation
@@ -102,3 +102,16 @@ class ListSerializerMixin(object):
         if self.action == 'list':
             return getattr(self, 'listserializer_class', self.serializer_class)
         return super(ListSerializerMixin, self).get_serializer_class()
+
+
+class HtmlViewField(serializers.ReadOnlyField):
+    def __init__(self, *args, **kwargs):
+        super(HtmlViewField, self).__init__(*args, **kwargs)
+
+    def get_attribute(self, obj):
+        return obj
+
+    def to_representation(self, obj):
+        request = self.context['request']
+        url = obj.get_absolute_url()
+        return request.build_absolute_uri(url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Django==1.7.7
 django-bootstrap-form==3.2
 django-tastypie==0.12.1
 djangorestframework==3.3.3
+-e git+https://github.com/raphendyr/drf-extensions.git@d8878beea0b051170262f7ca10edc9bf9ec76ddb#egg=drf_extensions
 feedparser
 html5lib
 icalendar==3.9.0

--- a/userprofile/api/serializers.py
+++ b/userprofile/api/serializers.py
@@ -3,27 +3,37 @@ from rest_framework import serializers
 from ..models import UserProfile
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
-    """"
-    Add the details of a user. This has to be done here because
-    details are in User-model, not in UserProfile which has OneToOneField
-    to a User-model
-    """
-    url = serializers.HyperlinkedIdentityField(view_name='api:user-detail', lookup_field='user_id', format='html')
+class UserBriefSerialiser(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        source='user.id',
+        view_name='api:user-detail',
+        lookup_url_kwarg='user_id',
+        format='html',
+    )
     user_id = serializers.IntegerField(source='user.id')
     username = serializers.CharField(source='user.username')
-    first_name = serializers.CharField(source='user.first_name')
-    last_name = serializers.CharField(source='user.last_name')
-    email = serializers.CharField(source='user.email')
 
     class Meta:
         model = UserProfile
         fields = (
             'url',
             'user_id',
+            'username'
+        )
+
+class UserSerializer(UserBriefSerialiser):
+    """
+    Add the details of a user.
+    """
+
+    first_name = serializers.CharField(source='user.first_name')
+    last_name = serializers.CharField(source='user.last_name')
+    email = serializers.CharField(source='user.email')
+
+    class Meta(UserBriefSerialiser.Meta):
+        fields = UserBriefSerialiser.Meta.fields + (
             'student_id',
-            'username',
             'first_name',
             'last_name',
             'email',
-            )
+        )

--- a/userprofile/api/tests.py
+++ b/userprofile/api/tests.py
@@ -19,33 +19,17 @@ class UserProfileAPITest(TestCase):
             'count': 4, 'next': None, 'previous': None,
             'results': [
                 {'url': 'http://testserver/api/v2/users/1/',
-                 'first_name': 'Superb',
                  'user_id': 1,
-                 'username': 'testUser',
-                 'student_id': '12345X',
-                 'email': 'test@aplus.com',
-                 'last_name': 'Student'},
+                 'username': 'testUser'},
                 {'url': 'http://testserver/api/v2/users/2/',
-                 'first_name': 'Grumpy',
                  'user_id': 2,
-                 'username': 'grader',
-                 'student_id': '67890Y',
-                 'email': 'grader@aplus.com',
-                 'last_name': 'Grader'},
+                 'username': 'grader'},
                 {'url': 'http://testserver/api/v2/users/3/',
-                 'first_name': 'Tedious',
                  'user_id': 3,
-                 'username': 'teacher',
-                 'student_id': None,
-                 'email': 'teacher@aplus.com',
-                 'last_name': 'Teacher'},
+                 'username': 'teacher'},
                 {'url': 'http://testserver/api/v2/users/4/',
-                 'first_name': 'Super',
                  'user_id': 4,
-                 'username': 'superuser',
-                 'student_id': None,
-                 'email': 'superuser@aplus.com',
-                 'last_name': 'User'}
+                 'username': 'superuser'}
                 ]
             })
 

--- a/userprofile/api/views.py
+++ b/userprofile/api/views.py
@@ -1,14 +1,18 @@
 from rest_framework import generics, permissions, viewsets
 
+from lib.api import ListSerializerMixin
+
 from ..models import UserProfile
-from .serializers import UserSerializer
+from .serializers import \
+    UserSerializer, UserBriefSerialiser
 
 
-class UserViewSet(viewsets.ReadOnlyModelViewSet):
+class UserViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
     queryset = UserProfile.objects.all()
-    serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
     lookup_field = 'user_id'
+    listserializer_class = UserBriefSerialiser
+    serializer_class = UserSerializer
 
     # if update is required, change to normal modelviewset and
     # change permissions


### PR DESCRIPTION
Implementation of api resource courses for api v2.

For now we use development version of drf-extensions as the nested routes is not yet merged to upstream. I expect this to be done, before we hit production or it should be copied to a-plus repo.

There is no links to exercise resource as it's not present in this branch.