### PR TITLE
Feature: api rework

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -33,6 +33,10 @@ with api.register(r'exercises',
                        exercise.api.views.ExerciseSubmissionsViewSet,
                        base_name='exercise-submissions')
 
+api.register(r'submissions',
+             exercise.api.views.SubmissionViewSet,
+             base_name='submission')
+
 urlpatterns = [
     url(r'^', include(api.urls, namespace='api')),
 

--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -32,6 +32,9 @@ with api.register(r'exercises',
     exercises.register(r'submissions',
                        exercise.api.views.ExerciseSubmissionsViewSet,
                        base_name='exercise-submissions')
+    exercises.register(r'submitter_stats',
+                       exercise.api.views.ExerciseSubmitterStatsViewSet,
+                       base_name='exervise-submitter_stats')
 
 api.register(r'submissions',
              exercise.api.views.SubmissionViewSet,

--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -2,9 +2,8 @@ from django.conf import settings
 from django.conf.urls import url, include
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 
-import userprofile.api.views, \
-       course.api.views
-from exercise.api.views import *
+import userprofile.api.views
+import course.api.views
 import exercise.api.views
 
 
@@ -13,13 +12,6 @@ api = ExtendedDefaultRouter()
 api.register(r'users',
              userprofile.api.views.UserViewSet,
              base_name='user')
-
-with api.register(r'exercises',
-                    exercise.api.views.ExerciseViewSet,
-                    base_name='exercise') as exercises:
-    exercises.register(r'submissions',
-                        exercise.api.views.ExerciseSubmissionsViewSet,
-                        base_name='exercise-submissions')
 
 with api.register(r'courses',
                   course.api.views.CourseViewSet,
@@ -33,6 +25,13 @@ with api.register(r'courses',
     courses.register(r'points',
                      course.api.views.CoursePointsViewSet,
                      base_name='course-points')
+
+with api.register(r'exercises',
+                  exercise.api.views.ExerciseViewSet,
+                  base_name='exercise') as exercises:
+    exercises.register(r'submissions',
+                       exercise.api.views.ExerciseSubmissionsViewSet,
+                       base_name='exercise-submissions')
 
 urlpatterns = [
     url(r'^', include(api.urls, namespace='api')),

--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -41,6 +41,7 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    print(" API URLS:")
-    for url in api.urls:
-        print("  - %r" % (url,))
+    _len = max((len(url.name) for url in api.urls))
+    _fmt = "  - %%-%ds %%s" % (_len,)
+    _urls = '\n'.join((_fmt % (url.name, url.regex.pattern) for url in api.urls))
+    print(" API URLS:\n%s" % (_urls,))

--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -38,10 +38,6 @@ urlpatterns = [
     url(r'^', include(api.urls, namespace='api')),
 
     url(r'^me', userprofile.api.views.MeDetail.as_view()),
-
-    # For login/logout etc. pages in Django REST Framework
-    url(r'^api-auth/', include('rest_framework.urls',
-                               namespace='rest_framework')),
 ]
 
 if settings.DEBUG:

--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -230,11 +230,11 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_RENDERER_CLASSES': (
-        'lib.api.APlusJSONRenderer',
+        'lib.api.core.APlusJSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
-    'DEFAULT_CONTENT_NEGOTIATION_CLASS': 'lib.api.APlusContentNegotiation',
-    'DEFAULT_VERSIONING_CLASS': 'lib.api.APlusVersioning',
+    'DEFAULT_CONTENT_NEGOTIATION_CLASS': 'lib.api.core.APlusContentNegotiation',
+    'DEFAULT_VERSIONING_CLASS': 'lib.api.core.APlusVersioning',
     'PAGE_SIZE': 100,
     'DEFAULT_VERSION': '2',
     'ALLOWED_VERSIONS': {

--- a/course/api/full_serializers.py
+++ b/course/api/full_serializers.py
@@ -1,0 +1,54 @@
+from rest_framework import serializers
+from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
+from lib.api.serializers import AplusModelSerializer
+
+from exercise.api.serializers import ExerciseBriefSerializer
+from ..models import CourseModule
+from .serializers import CourseBriefSerializer
+
+
+__all__ = [
+    'CourseModuleSerializer',
+    'CourseSerializer',
+]
+
+
+class CourseModuleSerializer(AplusModelSerializer):
+    url = NestedHyperlinkedIdentityField(view_name='api:course-exercises-detail')
+    exercises = serializers.SerializerMethodField()
+    display_name = serializers.CharField(source='__str__')
+
+    class Meta(AplusModelSerializer.Meta):
+        model = CourseModule
+        fields = (
+            'url',
+            'html_url',
+            'display_name',
+            'is_open',
+            'exercises',
+        )
+
+    def get_exercises(self, obj):
+        # this needs to be method so .as_leaf_class() can be called
+        exercises = obj.flat_learning_objects(with_sub_markers=False)
+        exercises = (e.as_leaf_class() for e in exercises)
+        serializer = ExerciseBriefSerializer(instance=exercises, many=True, context=self.context)
+        return serializer.data
+
+
+class CourseSerializer(CourseBriefSerializer):
+    """
+    ...
+    """
+    exercises = NestedHyperlinkedIdentityField(view_name='api:course-exercises-list', format='html')
+    students = NestedHyperlinkedIdentityField(view_name='api:course-students-list', format='html')
+    points = NestedHyperlinkedIdentityField(view_name='api:course-points-list', format='html')
+
+    class Meta(CourseBriefSerializer.Meta):
+        fields = (
+            'starting_time',
+            'ending_time',
+            'exercises',
+            'students',
+            'points',
+        )

--- a/course/api/serializers.py
+++ b/course/api/serializers.py
@@ -1,94 +1,40 @@
 from rest_framework import serializers
 from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
-from lib.api.serializers import HtmlViewField
-
-from userprofile.api.serializers import UserBriefSerialiser
+from lib.api.serializers import AplusModelSerializer, AlwaysListSerializer
 
 from ..models import (
     CourseInstance,
     CourseModule,
 )
-from exercise.models import BaseExercise
 
 
 __all__ = [
-    'LearningObjectSerializer',
-    'CourseModuleSerializer',
     'CourseBriefSerializer',
-    'CourseSerializer',
+    'CourseListField',
 ]
 
 
-class LearningObjectSerializer(serializers.HyperlinkedModelSerializer):
-    html_url = HtmlViewField()
-    display_name = serializers.CharField(source='__str__')
-
-    class Meta:
-        model = BaseExercise
-        fields = (
-            'html_url',
-            'display_name',
-            'is_submittable',
-        )
-
-
-class CourseModuleSerializer(serializers.HyperlinkedModelSerializer):
-    url = NestedHyperlinkedIdentityField(view_name='api:course-exercises-detail', format='html')
-    html_url = HtmlViewField()
-    exercises = serializers.SerializerMethodField()
-    display_name = serializers.CharField(source='__str__')
-
-    class Meta:
-        model = CourseModule
-        fields = (
-            'url',
-            'html_url',
-            'display_name',
-            'exercises',
-            'is_open',
-        )
-
-    def get_exercises(self, obj):
-        exercises = obj.flat_learning_objects(with_sub_markers=False)
-        exercises = (e.as_leaf_class() for e in exercises)
-        serializer = LearningObjectSerializer(instance=exercises, many=True, context=self.context)
-        return serializer.data
-
-
-class CourseBriefSerializer(serializers.HyperlinkedModelSerializer):
+class CourseBriefSerializer(AplusModelSerializer):
     """
     ...
     """
-    url = NestedHyperlinkedIdentityField(view_name='api:course-detail', format='html')
-    html_url = HtmlViewField()
-    course_id = serializers.IntegerField(source='id')
-    course_code = serializers.CharField(source='course.code')
-    course_name = serializers.CharField(source='course.name')
+    url = NestedHyperlinkedIdentityField(
+        view_name='api:course-detail',
+        lookup_map='course.api.views.CourseViewSet'
+    )
+    code = serializers.CharField(source='course.code')
+    name = serializers.CharField(source='course.name')
 
-    class Meta:
+    class Meta(AplusModelSerializer.Meta):
         model = CourseInstance
         fields = (
             'url',
             'html_url',
-            'course_id',
-            'course_code',
-            'course_name',
+            'code',
+            'name',
             'instance_name',
         )
 
-class CourseSerializer(CourseBriefSerializer):
-    """
-    ...
-    """
-    exercises = NestedHyperlinkedIdentityField(view_name='api:course-exercises-list', format='html')
-    students = NestedHyperlinkedIdentityField(view_name='api:course-students-list', format='html')
-    points = NestedHyperlinkedIdentityField(view_name='api:course-points-list', format='html')
 
-    class Meta(CourseBriefSerializer.Meta):
-        fields = CourseBriefSerializer.Meta.fields + (
-            'starting_time',
-            'ending_time',
-            'exercises',
-            'students',
-            'points',
-        )
+class CourseListField(AlwaysListSerializer, CourseBriefSerializer):
+    pass

--- a/course/api/serializers.py
+++ b/course/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
-from lib.api import HtmlViewField
+from lib.api.serializers import HtmlViewField
 
 from userprofile.api.serializers import UserBriefSerialiser
 
@@ -9,6 +9,14 @@ from ..models import (
     CourseModule,
 )
 from exercise.models import BaseExercise
+
+
+__all__ = [
+    'LearningObjectSerializer',
+    'CourseModuleSerializer',
+    'CourseBriefSerializer',
+    'CourseSerializer',
+]
 
 
 class LearningObjectSerializer(serializers.HyperlinkedModelSerializer):

--- a/course/api/views.py
+++ b/course/api/views.py
@@ -4,47 +4,42 @@ from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework import status
 from rest_framework.reverse import reverse
+
 from lib.api import ListSerializerMixin
+from userprofile.models import UserProfile
+from userprofile.api.serializers import UserBriefSerialiser
+from exercise.models import BaseExercise
+from exercise.presentation.results import ResultTable
 
 from ..models import (
     CourseInstance,
     CourseModule,
 )
-from .serializers import (
-    CourseBriefSerializer,
-    CourseSerializer,
-    CourseModuleSerializer,
-)
-from userprofile.models import UserProfile
-from userprofile.api.serializers import UserBriefSerialiser
-from exercise.models import BaseExercise
-
-# For fetching points on specific course
-from exercise.presentation.results import ResultTable
+from .serializers import *
 
 
 class CourseViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
-    queryset = CourseInstance.objects.filter(visible_to_students=True)
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'course_id'
     listserializer_class = CourseBriefSerializer
     serializer_class = CourseSerializer
+    queryset = CourseInstance.objects.all().filter(visible_to_students=True)
 
 
 class CourseExercisesViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'exercisemodule_id'
+    parent_lookup_map = {'course_id': 'course_instance.id'}
     serializer_class = CourseModuleSerializer
     queryset = CourseModule.objects.all()
-    parent_lookup_map = {'course_id': 'course_instance.id'}
 
 
 class CourseStudentsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'user_id'
+    parent_lookup_map = {'course_id': 'enrolled.id'}
     serializer_class = UserBriefSerialiser
     queryset = UserProfile.objects.all()
-    parent_lookup_map = {'course_id': 'enrolled.id'}
 
 
 class CoursePointsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):

--- a/course/api/views.py
+++ b/course/api/views.py
@@ -58,7 +58,7 @@ class CoursePointsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         Also there's included points to pass value in course module
         and total of gathered points in that module
         """
-        course_instance = CourseInstance.objects.get(course=course_id)
+        course_instance = CourseInstance.objects.get(id=course_id)
         table = ResultTable(course_instance)
         try:
             student_id = int(pk)
@@ -81,7 +81,7 @@ class CoursePointsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         """
         For listing this courses students and links to their points
         """
-        course_instance = CourseInstance.objects.get(course=course_id)
+        course_instance = CourseInstance.objects.get(id=course_id)
         table = ResultTable(course_instance)
 
         students_results = {}

--- a/course/api/views.py
+++ b/course/api/views.py
@@ -5,9 +5,10 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from lib.api.mixins import ListSerializerMixin
+from lib.api.mixins import ListSerializerMixin, MeUserMixin
+from lib.api.constants import REGEX_INT, REGEX_INT_ME
 from userprofile.models import UserProfile
-from userprofile.api.serializers import UserBriefSerialiser
+from userprofile.api.serializers import UserBriefSerializer
 from exercise.models import BaseExercise
 from exercise.presentation.results import ResultTable
 
@@ -16,11 +17,13 @@ from ..models import (
     CourseModule,
 )
 from .serializers import *
+from .full_serializers import *
 
 
 class CourseViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'course_id'
+    lookup_value_regex = REGEX_INT
     listserializer_class = CourseBriefSerializer
     serializer_class = CourseSerializer
     queryset = CourseInstance.objects.all().filter(visible_to_students=True)
@@ -29,16 +32,20 @@ class CourseViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
 class CourseExercisesViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'exercisemodule_id'
+    lookup_value_regex = REGEX_INT
     parent_lookup_map = {'course_id': 'course_instance.id'}
     serializer_class = CourseModuleSerializer
     queryset = CourseModule.objects.all()
 
 
-class CourseStudentsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
+class CourseStudentsViewSet(NestedViewSetMixin,
+                            MeUserMixin,
+                            viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'user_id'
+    lookup_value_regex = REGEX_INT_ME
     parent_lookup_map = {'course_id': 'enrolled.id'}
-    serializer_class = UserBriefSerialiser
+    serializer_class = UserBriefSerializer
     queryset = UserProfile.objects.all()
 
 

--- a/course/api/views.py
+++ b/course/api/views.py
@@ -5,7 +5,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from lib.api import ListSerializerMixin
+from lib.api.mixins import ListSerializerMixin
 from userprofile.models import UserProfile
 from userprofile.api.serializers import UserBriefSerialiser
 from exercise.models import BaseExercise

--- a/exercise/api/full_serializers.py
+++ b/exercise/api/full_serializers.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
 
 from lib.api.serializers import (
+    AlwaysListSerializer,
+    CompositeListSerializer,
     AplusSerializerMeta,
     AplusModelSerializerBase,
 )
@@ -17,6 +19,7 @@ from .serializers import (
 __all__ = [
     'ExerciseSerializer',
     'SubmitterStatsSerializer',
+    'UserListFieldWithStatsLink',
     'SubmissionSerializer',
     'SubmissionGradingSerializer',
 ]
@@ -91,9 +94,27 @@ class SubmitterStatsSerializer(serializers.Serializer):
         )
 
 
+class UserListFieldWithStatsLink(AlwaysListSerializer, UserBriefSerializer):
+    exercise_stats = NestedHyperlinkedIdentityField(
+        view_name='api:exervise-submitter_stats-detail',
+        lookup_map={
+            'exercise_id': 'exercise_id',
+            'user_id': 'id',
+        },
+    )
+
+    class Meta(UserBriefSerializer.Meta):
+        list_serializer_class = CompositeListSerializer.with_extra({
+            'exercise_id': 'exercise_id',
+        })
+        fields = (
+            'exercise_stats',
+        )
+
+
 class SubmissionSerializer(SubmissionBriefSerializer):
     exercise = ExerciseBriefSerializer()
-    submitters = UserBriefSerializer(many=True)
+    submitters = UserListFieldWithStatsLink()
 
     class Meta(SubmissionBriefSerializer.Meta):
         fields = (

--- a/exercise/api/full_serializers.py
+++ b/exercise/api/full_serializers.py
@@ -1,0 +1,61 @@
+from rest_framework import serializers
+from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
+
+from userprofile.api.serializers import UserListField
+
+from .serializers import (
+    ExerciseBriefSerializer,
+    SubmissionBriefSerializer,
+)
+
+
+__all__ = [
+    'ExerciseSerializer',
+    'SubmissionSerializer',
+]
+
+
+class ExerciseSerializer(ExerciseBriefSerializer):
+    post_url = serializers.SerializerMethodField()
+    submissions = NestedHyperlinkedIdentityField(
+        view_name='api:exercise-submissions-list',
+        lookup_map='exercise.api.views.ExerciseViewSet',
+    )
+    my_submissions = NestedHyperlinkedIdentityField(
+        view_name='api:exercise-submissions-detail',
+        lookup_map={
+            'exercise_id': 'id',
+            'user_id': lambda o=None: 'me',
+        },
+    )
+
+    def get_post_url(self, obj):
+        # FIXME: obj should implement .get_post_url() and that should be used here
+        if obj.is_submittable:
+            request = self.context['request']
+            url = obj.get_url("exercise")
+            return request.build_absolute_uri(url)
+        return None
+
+    class Meta(ExerciseBriefSerializer.Meta):
+        fields = (
+            'is_submittable',
+            'post_url',
+            'submissions',
+            'my_submissions',
+        )
+
+
+class SubmissionSerializer(SubmissionBriefSerializer):
+    #exercises = NestedHyperlinkedIdentityField(view_name='api:course-exercises-list', format='html')
+    submitters = UserListField()
+    #NestedHyperlinkedIdentityField(view_name='api:course-students-list', format='html')
+
+    class Meta(SubmissionBriefSerializer.Meta):
+        fields = (
+            'html_url',
+            #'exercise',
+            'submitters',
+            #'submission_data',
+            #'is_submittable',
+        )

--- a/exercise/api/full_serializers.py
+++ b/exercise/api/full_serializers.py
@@ -7,6 +7,7 @@ from lib.api.serializers import (
     AplusSerializerMeta,
     AplusModelSerializerBase,
 )
+from course.api.serializers import CourseBriefSerializer
 from userprofile.api.serializers import UserBriefSerializer
 
 from ..models import Submission
@@ -26,6 +27,7 @@ __all__ = [
 
 
 class ExerciseSerializer(ExerciseBriefSerializer):
+    course = CourseBriefSerializer(source='course_instance')
     post_url = serializers.SerializerMethodField()
     submissions = NestedHyperlinkedIdentityField(
         view_name='api:exercise-submissions-list',
@@ -56,6 +58,7 @@ class ExerciseSerializer(ExerciseBriefSerializer):
 
     class Meta(ExerciseBriefSerializer.Meta):
         fields = (
+            'course',
             'is_submittable',
             'post_url',
             'max_points',

--- a/exercise/api/serializers.py
+++ b/exercise/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
+
 from lib.api.serializers import AplusModelSerializer
 
 from ..models import Submission, BaseExercise
@@ -32,9 +33,9 @@ class SubmissionBriefSerializer(AplusModelSerializer):
 
     class Meta(AplusModelSerializer.Meta):
         model = Submission
-        #fields = (
-        #    'display_name',
-        #)
+        fields = (
+            'submission_time',
+        )
         extra_kwargs = {
             'url': {
                 'view_name': 'api:submission-detail',

--- a/exercise/api/serializers.py
+++ b/exercise/api/serializers.py
@@ -1,6 +1,13 @@
 from rest_framework import serializers
-from lib.api import HtmlViewField
+from lib.api.serializers import HtmlViewField
 from ..models import LearningObject, Submission, BaseExercise
+
+
+__all__ = [
+    'LearningObjectSerializer',
+    'SubmissionSerializer',
+]
+
 
 # LearningObject is base of exercises.
 class LearningObjectSerializer(serializers.ModelSerializer):

--- a/exercise/api/serializers.py
+++ b/exercise/api/serializers.py
@@ -1,31 +1,43 @@
 from rest_framework import serializers
-from lib.api.serializers import HtmlViewField
-from ..models import LearningObject, Submission, BaseExercise
+from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
+from lib.api.serializers import AplusModelSerializer
+
+from ..models import Submission, BaseExercise
 
 
 __all__ = [
-    'LearningObjectSerializer',
-    'SubmissionSerializer',
+    'ExerciseBriefSerializer',
+    'SubmissionBriefSerializer',
 ]
 
 
-# LearningObject is base of exercises.
-class LearningObjectSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = LearningObject
-        fields = ('name', 'course_module', 'url', 'content', 'service_url', 'objects')
-
-class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
-    html_url = HtmlViewField()
+class ExerciseBriefSerializer(AplusModelSerializer):
+    url = NestedHyperlinkedIdentityField(
+        view_name='api:exercise-detail',
+        lookup_map='exercise.api.views.ExerciseViewSet',
+    )
     display_name = serializers.CharField(source='__str__')
 
-    class Meta:
-        model = Submission
+    class Meta(AplusModelSerializer.Meta):
+        model = BaseExercise
         fields = (
+            'url',
             'html_url',
-            'exercise',
-            'submitters',
-            'submission_data',
             'display_name',
-            'is_submittable',
         )
+
+
+class SubmissionBriefSerializer(AplusModelSerializer):
+    #display_name = serializers.CharField(source='__str__')
+
+    class Meta(AplusModelSerializer.Meta):
+        model = Submission
+        #fields = (
+        #    'display_name',
+        #)
+        extra_kwargs = {
+            'url': {
+                'view_name': 'api:submission-detail',
+                'lookup_map': 'exercise.api.views.SubmissionViewSet',
+            }
+        }

--- a/exercise/api/tests.py
+++ b/exercise/api/tests.py
@@ -81,5 +81,5 @@ class ExerciceSubmissionAPITest(TestCase):
         """
         client = APIClient()
         client.force_authenticate(user=self.student)
-        response = client.get('/api/v2/exercises/1/submissions/1/')
+        response = client.get('/api/v2/submissions/1/')
         self.assertEqual(response.data, {'detail': 'Not found.'})

--- a/exercise/api/views.py
+++ b/exercise/api/views.py
@@ -1,27 +1,34 @@
-from rest_framework import generics, permissions, viewsets
-from rest_framework.authentication import TokenAuthentication
-from ..models import LearningObject, Submission, BaseExercise, SubmissionManager
-from rest_framework_extensions.mixins import NestedViewSetMixin
 from django.http import HttpResponse
-from rest_framework.response import Response
+from rest_framework import mixins, permissions, viewsets
 from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.response import Response
+from rest_framework_extensions.mixins import NestedViewSetMixin
+
+from ..models import (
+    Submission,
+    BaseExercise,
+    SubmissionManager,
+)
 from .serializers import *
 from course.api.serializers import LearningObjectSerializer as ExerciseSerializer
-from rest_framework import mixins
 
-class ExerciseViewSet(mixins.RetrieveModelMixin,
-                                viewsets.GenericViewSet):
+
+class ExerciseViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     """
     Url for GETting information about an exercise. (List of exercises can be
     fetched from /api/v2/courses/1/exercices)
     /api/v2/exercises/{exercise_id} (/api/v2/exercises/ does not actually exist)
     """
-    queryset = BaseExercise.objects.all()
-    serializer_class = ExerciseSerializer
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'exercise_id'
+    serializer_class = ExerciseSerializer
+    queryset = BaseExercise.objects.all()
 
-class ExerciseSubmissionsViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
+
+class ExerciseSubmissionsViewSet(NestedViewSetMixin,
+                                 mixins.ListModelMixin,
+                                 viewsets.GenericViewSet):
     """
     * /api/v2/exercises/{exercise_id}/submissions
     * POST: Make a submission. Returns brief information about submission
@@ -31,10 +38,10 @@ class ExerciseSubmissionsViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     """
     permission_classes = [permissions.IsAuthenticated]
     authentication_classes = (TokenAuthentication,) # CSRF validation skipped
-    serializer_class = SubmissionSerializer
-    queryset = Submission.objects.all()
     lookup_url_kwarg = 'exercise_submissions'
     parent_lookup_map = {'exercise_id': 'exercise.id'}
+    serializer_class = SubmissionSerializer
+    queryset = Submission.objects.all()
 
     # For POSTing a submission. An extra parameter exercise_id comes
     # from url. UNDER CONSTRUCTION!

--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -118,6 +118,7 @@ def _get_async_submission_info(exercise, students):
             submitters__in=students) \
         .order_by('-grade')
 
+    # FIXME: does count submissions that are not supposed to be counted
     submission_count = submissions.count()
     if submission_count > 0:
         current_points = submissions.first().grade

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -223,6 +223,7 @@ class Submission(UrlMixin, models.Model):
             return False
         return True
 
+    @property
     def is_graded(self):
         return self.status == self.STATUS_READY
 

--- a/exercise/templatetags/exercise.py
+++ b/exercise/templatetags/exercise.py
@@ -80,7 +80,7 @@ def submission_points(submission, classes=None):
         "passed": passed,
         "full_score": submission.grade >= exercise.max_points,
         "submitted": True,
-        "status": False if submission.is_graded() else submission.status
+        "status": False if submission.is_graded else submission.status
     }
 
 

--- a/exercise/tests.py
+++ b/exercise/tests.py
@@ -478,21 +478,21 @@ class ExerciseTest(TestCase):
 
     def test_submission_status(self):
         self.assertEqual("initialized", self.submission.status)
-        self.assertFalse(self.submission.is_graded())
+        self.assertFalse(self.submission.is_graded)
         self.submission.set_error()
         self.assertEqual("error", self.submission.status)
-        self.assertFalse(self.submission.is_graded())
+        self.assertFalse(self.submission.is_graded)
         self.submission.set_waiting()
         self.assertEqual("waiting", self.submission.status)
-        self.assertFalse(self.submission.is_graded())
+        self.assertFalse(self.submission.is_graded)
         self.submission.set_error()
         self.assertEqual("error", self.submission.status)
-        self.assertFalse(self.submission.is_graded())
+        self.assertFalse(self.submission.is_graded)
         self.assertEqual(None, self.submission.grading_time)
         self.submission.set_ready()
         self.assertIsInstance(self.submission.grading_time, datetime)
         self.assertEqual("ready", self.submission.status)
-        self.assertTrue(self.submission.is_graded())
+        self.assertTrue(self.submission.is_graded)
 
     def test_submission_absolute_url(self):
         self.assertEqual("/Course-Url/T-00.1000_d1/test-module/b1/submissions/1/", self.submission.get_absolute_url())

--- a/lib/api/constants.py
+++ b/lib/api/constants.py
@@ -1,0 +1,2 @@
+REGEX_INT = '[0-9]+'
+REGEX_INT_ME = '([0-9]+|me)'

--- a/lib/api/core.py
+++ b/lib/api/core.py
@@ -1,15 +1,17 @@
 from distutils.version import LooseVersion as _version
 
-from rest_framework import exceptions, serializers
+from rest_framework import exceptions
 from rest_framework.renderers import JSONRenderer
 from rest_framework.versioning import AcceptHeaderVersioning, URLPathVersioning
 from rest_framework.negotiation import DefaultContentNegotiation
 from rest_framework.compat import unicode_http_header
 from rest_framework.utils import mediatypes
 
+
 # define this here as it's project dependent and not installation
 # there is no point to redefine it ever
 APLUS_JSON_TYPE = 'application/vnd.aplus+json'
+
 
 class _MediaType(mediatypes._MediaType):
     """
@@ -95,23 +97,3 @@ class APlusContentNegotiation(DefaultContentNegotiation):
                 accept = str(mt)
             accepts.append(accept)
         return accepts
-
-
-class ListSerializerMixin(object):
-    def get_serializer_class(self):
-        if self.action == 'list':
-            return getattr(self, 'listserializer_class', self.serializer_class)
-        return super(ListSerializerMixin, self).get_serializer_class()
-
-
-class HtmlViewField(serializers.ReadOnlyField):
-    def __init__(self, *args, **kwargs):
-        super(HtmlViewField, self).__init__(*args, **kwargs)
-
-    def get_attribute(self, obj):
-        return obj
-
-    def to_representation(self, obj):
-        request = self.context['request']
-        url = obj.get_absolute_url()
-        return request.build_absolute_uri(url)

--- a/lib/api/mixins.py
+++ b/lib/api/mixins.py
@@ -1,5 +1,18 @@
 class ListSerializerMixin(object):
+    # FIXME: use rest_framework_extensions.mixins.DetailSerializerMixin
     def get_serializer_class(self):
         if self.action == 'list':
             return getattr(self, 'listserializer_class', self.serializer_class)
         return super(ListSerializerMixin, self).get_serializer_class()
+
+
+class MeUserMixin(object):
+    me_user_url_kw = 'user_id'
+    me_user_value = 'me'
+
+    def dispatch(self, request, *args, **kwargs):
+        kw = self.me_user_url_kw
+        value = kwargs.get(kw, None)
+        if value and self.me_user_value == value:
+            kwargs[kw] = request.user.id
+        return super(MeUserMixin, self).dispatch(request, *args, **kwargs)

--- a/lib/api/mixins.py
+++ b/lib/api/mixins.py
@@ -1,0 +1,5 @@
+class ListSerializerMixin(object):
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return getattr(self, 'listserializer_class', self.serializer_class)
+        return super(ListSerializerMixin, self).get_serializer_class()

--- a/lib/api/serializers.py
+++ b/lib/api/serializers.py
@@ -15,10 +15,8 @@ class AlwaysListSerializer(object):
 
 class HtmlViewField(serializers.ReadOnlyField):
     def __init__(self, *args, **kwargs):
+        kwargs['source'] = '*'
         super(HtmlViewField, self).__init__(*args, **kwargs)
-
-    def get_attribute(self, obj):
-        return obj
 
     def to_representation(self, obj):
         request = self.context['request']

--- a/lib/api/serializers.py
+++ b/lib/api/serializers.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+
+
+class HtmlViewField(serializers.ReadOnlyField):
+    def __init__(self, *args, **kwargs):
+        super(HtmlViewField, self).__init__(*args, **kwargs)
+
+    def get_attribute(self, obj):
+        return obj
+
+    def to_representation(self, obj):
+        request = self.context['request']
+        url = obj.get_absolute_url()
+        return request.build_absolute_uri(url)

--- a/lib/api/serializers.py
+++ b/lib/api/serializers.py
@@ -46,17 +46,9 @@ class AplusSerializerMeta(metaclass=AplusSerializerMetaMetaclass):
     pass
 
 
-class AplusModelSerializer(NestedHyperlinkedModelSerializer):
+class AplusModelSerializerBase(NestedHyperlinkedModelSerializer):
     url_field_name = 'url'
     html_url_field_name = 'html_url'
-
-    class Meta(AplusSerializerMeta):
-        fields = (
-            'id',
-            'url',
-        )
-
-    id = serializers.IntegerField(source='pk', read_only=True)
 
     def get_field_names(self, declared_fields, info):
         fields = list(super().get_field_names(declared_fields, info))
@@ -74,3 +66,13 @@ class AplusModelSerializer(NestedHyperlinkedModelSerializer):
             kwargs.update(extra_kwargs[self.url_field_name])
             return (NestedHyperlinkedIdentityField, kwargs)
         return super().build_unknown_field(field_name, model_class)
+
+
+class AplusModelSerializer(AplusModelSerializerBase):
+    id = serializers.IntegerField(source='pk', read_only=True)
+
+    class Meta(AplusSerializerMeta):
+        fields = (
+            'id',
+            'url',
+        )

--- a/lib/api/serializers.py
+++ b/lib/api/serializers.py
@@ -1,4 +1,16 @@
 from rest_framework import serializers
+from rest_framework_extensions.fields import NestedHyperlinkedIdentityField
+from rest_framework_extensions.serializers import NestedHyperlinkedModelSerializer
+
+
+class AlwaysListSerializer(object):
+    def __new__(cls, *args, **kwargs):
+        if kwargs.pop('_many', True):
+            kwargs['many'] = True
+        return super(AlwaysListSerializer, cls).__new__(cls, *args, _many=False, **kwargs)
+
+    def __init__(self, *args, _many=False, **kwargs):
+        super(AlwaysListSerializer, self).__init__(*args, **kwargs)
 
 
 class HtmlViewField(serializers.ReadOnlyField):
@@ -12,3 +24,55 @@ class HtmlViewField(serializers.ReadOnlyField):
         request = self.context['request']
         url = obj.get_absolute_url()
         return request.build_absolute_uri(url)
+
+
+class AplusSerializerMetaMetaclass(type):
+    def __new__(cls, name, bases, dict_):
+        new_cls = type.__new__(cls, name, bases, dict_)
+        for k, v in dict_.items():
+            if k[0] != '_' and not callable(v):
+                if isinstance(v, dict):
+                    parent = getattr(super(new_cls, new_cls), k, {})
+                    setattr(new_cls, k, dict(parent, **v))
+                elif isinstance(v, (tuple, list)):
+                    parent = getattr(super(new_cls, new_cls), k, ())
+                    seen = set()
+                    seen_add = seen.add
+                    res = [x for x in parent if not (x in seen or seen_add(x))]
+                    res += (x for x in v if not (x in seen or seen_add(x)))
+                    setattr(new_cls, k, type(v)(res))
+        return new_cls
+
+
+class AplusSerializerMeta(metaclass=AplusSerializerMetaMetaclass):
+    pass
+
+
+class AplusModelSerializer(NestedHyperlinkedModelSerializer):
+    url_field_name = 'url'
+    html_url_field_name = 'html_url'
+
+    class Meta(AplusSerializerMeta):
+        fields = (
+            'id',
+            'url',
+        )
+
+    id = serializers.IntegerField(source='pk', read_only=True)
+
+    def get_field_names(self, declared_fields, info):
+        fields = list(super().get_field_names(declared_fields, info))
+        extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
+        if self.url_field_name not in fields and self.url_field_name in extra_kwargs:
+            fields.insert(0, self.url_field_name)
+        return fields
+
+    def build_unknown_field(self, field_name, model_class):
+        if field_name == self.html_url_field_name:
+            return (HtmlViewField, {})
+        if field_name == self.url_field_name:
+            extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
+            kwargs = {'context': self.context}
+            kwargs.update(extra_kwargs[self.url_field_name])
+            return (NestedHyperlinkedIdentityField, kwargs)
+        return super().build_unknown_field(field_name, model_class)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==1.7.7
 django-bootstrap-form==3.2
 django-tastypie==0.12.1
 djangorestframework==3.3.3
--e git+https://github.com/raphendyr/drf-extensions.git@d8878beea0b051170262f7ca10edc9bf9ec76ddb#egg=drf_extensions
+-e git+https://github.com/raphendyr/drf-extensions.git@5201aa008bc8ac8d70c712af187e1c7939a5e49c#egg=drf_extensions
 feedparser
 html5lib
 icalendar==3.9.0

--- a/userprofile/api/full_serializers.py
+++ b/userprofile/api/full_serializers.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers
+from lib.api.serializers import AplusModelSerializer
+
+from course.api.serializers import CourseListField
+from .serializers import UserBriefSerializer
+
+
+__all__ = [
+    'UserSerializer',
+]
+
+
+class UserSerializer(UserBriefSerializer):
+    """
+    Add the details of a user.
+    """
+
+    first_name = serializers.CharField(source='user.first_name')
+    last_name = serializers.CharField(source='user.last_name')
+    email = serializers.CharField(source='user.email')
+    enrolled_courses = CourseListField(source='enrolled')
+
+    class Meta(UserBriefSerializer.Meta):
+        fields = (
+            'enrolled_courses',
+            'student_id',
+            'first_name',
+            'last_name',
+            'email',
+        )

--- a/userprofile/api/serializers.py
+++ b/userprofile/api/serializers.py
@@ -4,6 +4,12 @@ from course.models import CourseInstance
 from ..models import UserProfile
 
 
+__all__ = [
+    'UserBriefSerialiser',
+    'UserSerializer',
+]
+
+
 class UserBriefSerialiser(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         source='user.id',

--- a/userprofile/api/serializers.py
+++ b/userprofile/api/serializers.py
@@ -1,61 +1,32 @@
 from rest_framework import serializers
+from lib.api.serializers import AplusModelSerializer, AlwaysListSerializer
 
-from course.models import CourseInstance
 from ..models import UserProfile
 
 
 __all__ = [
-    'UserBriefSerialiser',
-    'UserSerializer',
+    'UserBriefSerializer',
+    'UserListField',
 ]
 
 
-class UserBriefSerialiser(serializers.HyperlinkedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        source='user.id',
-        view_name='api:user-detail',
-        lookup_url_kwarg='user_id',
-        format='html',
-    )
-    user_id = serializers.IntegerField(source='user.id')
+class UserBriefSerializer(AplusModelSerializer):
+    id = serializers.IntegerField(source='user.id', read_only=True) # NOTE: userprofile.id != user.id
     username = serializers.CharField(source='user.username')
 
-    class Meta:
+    class Meta(AplusModelSerializer.Meta):
         model = UserProfile
         fields = (
-            'url',
-            'user_id',
-            'username'
+            'username',
         )
+        extra_kwargs = {
+            'url': {
+                'view_name': 'api:user-detail',
+                'lookup_map': 'userprofile.api.views.UserViewSet',
+            }
+        }
 
-class UserSerializer(UserBriefSerialiser):
-    """
-    Add the details of a user.
-    """
 
-    courses = serializers.SerializerMethodField('list_courses')
-    first_name = serializers.CharField(source='user.first_name')
-    last_name = serializers.CharField(source='user.last_name')
-    email = serializers.CharField(source='user.email')
+class UserListField(AlwaysListSerializer, UserBriefSerializer):
+    pass
 
-    def list_courses(self, userinstance):
-      # Get courses where the user is enrolled
-      enrolled_courses = []
-      for enrolled in userinstance.enrolled.all():
-          enrolled_courses.append({
-            "name": enrolled.__str__(),
-            "id": enrolled.id
-          })
-
-      # Return all coursetuples in list. Tuple consists of name of the course
-      # and the id of the course
-      return enrolled_courses
-
-    class Meta(UserBriefSerialiser.Meta):
-        fields = UserBriefSerialiser.Meta.fields + (
-            'courses',
-            'student_id',
-            'first_name',
-            'last_name',
-            'email',
-        )

--- a/userprofile/api/tests.py
+++ b/userprofile/api/tests.py
@@ -7,7 +7,7 @@ class UserProfileAPITest(TestCase):
     from ..tests import UserProfileTest
     setUp = UserProfileTest.setUp
 
-    def test_rest_userlist(self):
+    def test_get_userlist(self):
         """
         Test if list of users are given correctly via REST.
         This does not need any authentication.
@@ -18,30 +18,30 @@ class UserProfileAPITest(TestCase):
         self.assertEqual(response.data, {
             'count': 4, 'next': None, 'previous': None,
             'results': [
-                {'url': 'http://testserver/api/v2/users/1/',
-                 'user_id': 1,
+                {'id': 1,
+                 'url': 'http://testserver/api/v2/users/1/',
                  'username': 'testUser'},
-                {'url': 'http://testserver/api/v2/users/2/',
-                 'user_id': 2,
+                {'id': 2,
+                 'url': 'http://testserver/api/v2/users/2/',
                  'username': 'grader'},
-                {'url': 'http://testserver/api/v2/users/3/',
-                 'user_id': 3,
+                {'id': 3,
+                 'url': 'http://testserver/api/v2/users/3/',
                  'username': 'teacher'},
-                {'url': 'http://testserver/api/v2/users/4/',
-                 'user_id': 4,
+                {'id': 4,
+                 'url': 'http://testserver/api/v2/users/4/',
                  'username': 'superuser'}
                 ]
             })
 
-    def test_rest_singleuser(self):
+    def test_get_userdetail(self):
         client = APIClient()
         client.force_authenticate(user=self.superuser)
         response = client.get('/api/v2/users/1/')
         self.assertEqual(response.data, {
+            'id': 1,
             'url': 'http://testserver/api/v2/users/1/',
-            'user_id': 1,
             'student_id':'12345X',
-            'courses': [],
+            'enrolled_courses': [],
             'username':'testUser',
             'first_name':'Superb',
             'last_name':'Student',

--- a/userprofile/api/views.py
+++ b/userprofile/api/views.py
@@ -2,17 +2,21 @@ from rest_framework import permissions, viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from lib.api.mixins import ListSerializerMixin
+from lib.api.mixins import ListSerializerMixin, MeUserMixin
+from lib.api.constants import REGEX_INT_ME
 
 from ..models import UserProfile
 from .serializers import *
+from .full_serializers import *
 
 
 class UserViewSet(ListSerializerMixin,
+                  MeUserMixin,
                   viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_field = 'user_id'
-    listserializer_class = UserBriefSerialiser
+    lookup_value_regex = REGEX_INT_ME
+    listserializer_class = UserBriefSerializer
     serializer_class = UserSerializer
     queryset = UserProfile.objects.all()
 

--- a/userprofile/api/views.py
+++ b/userprofile/api/views.py
@@ -1,28 +1,24 @@
 from rest_framework import permissions, viewsets
 from rest_framework.views import APIView
-from rest_framework import authentication, permissions
 from rest_framework.response import Response
-from rest_framework.authtoken.models import Token
-from rest_framework.renderers import JSONRenderer
-
-from lib.api import ListSerializerMixin
 
 from lib.api import ListSerializerMixin
 
 from ..models import UserProfile
-from .serializers import \
-    UserSerializer, UserBriefSerialiser
+from .serializers import *
 
 
-class UserViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
-    queryset = UserProfile.objects.all()
+class UserViewSet(ListSerializerMixin,
+                  viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     lookup_field = 'user_id'
     listserializer_class = UserBriefSerialiser
     serializer_class = UserSerializer
+    queryset = UserProfile.objects.all()
 
     # if update is required, change to normal modelviewset and
     # change permissions
+
 
 class MeDetail(APIView):
     """

--- a/userprofile/api/views.py
+++ b/userprofile/api/views.py
@@ -2,7 +2,7 @@ from rest_framework import permissions, viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from lib.api import ListSerializerMixin
+from lib.api.mixins import ListSerializerMixin
 
 from ..models import UserProfile
 from .serializers import *


### PR DESCRIPTION
A lot of changes to API v2 backend. It should be now more mature and have better structure for future development. Set of helpers are under `lib/api`. 

Files `serializers.py` have only brief and similar serializers that **do not** depend on other serializers. Files `full_serializers.py` can include brief serializers from other modules/apps. This pattern is used so we don't end up with cyclic imports.

Important changes to work in progress api urls:

* `course_id` and `user_id` fields are now just `id` as all aplus objects returned by the api _should_ include `id` and `url` fields. `id` can be missing for objects that are virtual (e.g. `submissions/<id>/grading`)

* User detail field `courses` is renamed to `enrolled_courses`

* `exercises/<id>/submissions/<id>` is changed to `exercises/<id>/submissions/<user_id>` and both that and `exercises/<id>/submissions/` returns list of submissions linking to `submissions/<id>`.

* `exercises/<id>/submitter_stats/<user_id>` returns stats for the submitter (or 404) 

* `submissions/<id>/grading` initial interface for grading services (will replace current submission_url when ready)

* All locations where `user_id` is used, `me` can be given instead of user id. Mixin `MeUserMixin`will replace `me` with the `request.user.id`.

**NOTE**: requirements.txt updated with reference to new version of drf-extensions.

ps. Combined diff might not explain all changes well due to moved/split files.