### PR TITLE
Feature: api token in lti laucnh request

### DIFF
--- a/external_services/lti.py
+++ b/external_services/lti.py
@@ -4,6 +4,7 @@ from oauthlib.oauth1 import Client, SIGNATURE_HMAC, SIGNATURE_TYPE_BODY, \
     SIGNATURE_TYPE_QUERY
 import hashlib
 
+from aplus.api import api_reverse
 from lib.helpers import update_url_params
 
 
@@ -61,6 +62,15 @@ class LTIRequest(object):
             "tool_consumer_instance_guid": host + "/aplus",
             "tool_consumer_instance_name": "A+ LMS",
         })
+
+        if service.enable_api_access:
+            self.parameters.update({
+                # FIXME: we need request or full host with protocol here!
+                'custom_context_api': '//' + host + api_reverse("course-detail", kwargs={'course_id': instance.id}),
+                'custom_context_api_id': str(instance.id),
+                'custom_user_api_token': user.userprofile.api_token,
+            })
+
 
     def sign_post_parameters(self, url=None):
         client = Client(self.service.consumer_key,

--- a/external_services/lti.py
+++ b/external_services/lti.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 from django.utils.translation import get_language
 from oauthlib.common import urldecode
 from oauthlib.oauth1 import Client, SIGNATURE_HMAC, SIGNATURE_TYPE_BODY, \
@@ -71,6 +72,11 @@ class LTIRequest(object):
                 'custom_user_api_token': user.userprofile.api_token,
             })
 
+    def get_checksum_of_parameters(self):
+        sum = md5()
+        for key, value in sorted(self.parameters.items()):
+            sum.update("{}={};".format(key, value).encode('utf-8'))
+        return sum.hexdigest()
 
     def sign_post_parameters(self, url=None):
         client = Client(self.service.consumer_key,

--- a/external_services/migrations/0006_ltiservice_enable_api_access.py
+++ b/external_services/migrations/0006_ltiservice_enable_api_access.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('external_services', '0005_auto_20160829_1344'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiservice',
+            name='enable_api_access',
+            field=models.BooleanField(help_text="Enable sharing user's api token and course api url in lti launch request. This grants api access with user's privileges for the lti tool.", default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/external_services/models.py
+++ b/external_services/models.py
@@ -46,6 +46,10 @@ class LTIService(LinkService):
     '''
     A provider of an LTI service.
     '''
+    enable_api_access = models.BooleanField(
+        default=False,
+        help_text=_("Enable sharing user's api token and course api url in lti launch request. This grants api access with user's privileges for the lti tool."),
+    )
     consumer_key = models.CharField(
         max_length=128,
         help_text=_("The consumer key provided by the LTI service.")

--- a/external_services/templates/external_services/lti_form.html
+++ b/external_services/templates/external_services/lti_form.html
@@ -17,18 +17,44 @@
 		to the provider of this service.
 		{% endblocktrans %}
 	</p>
+	{% if service.enable_api_access %}
+	<p>
+		{% blocktrans %}
+		For this service also API token is transferred.
+		Thus this service will have full access to A+ API with your privileges and
+		could possibly do harm in you name.
+		System administrator can disable this feature for this service.
+		{% endblocktrans %}
+	</p>
+	</p>
+	{% endif %}
 	<p>
 		<a href="{{ site }}" target="_new">{{ site }}</a>
 	</p>
+</div>
+<div>
 	<p>
-	<br>
-	<form id="lti_login_form" method="POST" action="{{ service.url }}">
-		{% for entry in parameters %}
-		<input type="hidden" name="{{ entry.0 }}" value="{{ entry.1 }}" />
-		{% endfor %}
-		<input type="submit" value="{% blocktrans with name=service.menu_label %}Accept and continue to {{ name }}{% endblocktrans %}" class="btn btn-primary" />
-	</form>
+		<form id="lti_login_form" method="POST" action="{{ service.url }}">
+			{% for entry in parameters %}
+			<input type="hidden" name="{{ entry.0 }}" value="{{ entry.1 }}" />
+			{% endfor %}
+			<input type="submit" value="{% blocktrans with name=service.menu_label %}Accept and continue to {{ name }}{% endblocktrans %}" class="btn btn-primary" />
+			<a class="btn btn-default" data-toggle="collapse"
+			   aria-expaned="false" aria-controls="shared_variables"
+			   href="#shared_variables"
+			   >{% trans "Show shared variables" %}</a>
+		</form>
 	</p>
+</div>
+<div class="collapse" id="shared_variables">
+	<table class="card card-block">
+		{% for name, value in parameters|dictsort:"0.lower" %}
+		<tr>
+			<th>{{ name }}</th>
+			<td>{{ value }}</td>
+		</tr>
+		{% endfor %}
+	</table>
 </div>
 {% endblock %}
 

--- a/external_services/templates/external_services/lti_form.html
+++ b/external_services/templates/external_services/lti_form.html
@@ -19,12 +19,22 @@
 	</p>
 	{% if service.enable_api_access %}
 	<p>
-		{% blocktrans %}
-		For this service also API token is transferred.
-		Thus this service will have full access to A+ API with your privileges and
-		could possibly do harm in you name.
-		System administrator can disable this feature for this service.
-		{% endblocktrans %}
+		{% if is_course_staff %}
+			{% blocktrans %}
+			For this service also API token is tranferred,
+			thus giving this service access to A+ API with your privileges.
+			If this was not intended, change 'Enable api access' in django admin.
+			{% endblocktrans %}
+		{% else %}
+			{% blocktrans %}
+			For this service also API token is tranferred,
+			thus giving this service access to A+ API with your privileges.
+			That means service can for example read your student number,
+			course progress and submit solutions to exercises.
+			Course staff has enabled this feature and have checked that
+			the service behaves with your best interest in mind.
+			{% endblocktrans %}
+		{% endif %}
 	</p>
 	</p>
 	{% endif %}

--- a/external_services/templates/external_services/lti_form.html
+++ b/external_services/templates/external_services/lti_form.html
@@ -34,6 +34,10 @@
 </div>
 <div>
 	<p>
+		<input id="auto_accept" type="checkbox" value"1" checked="checked" />
+		<label for="auto_accept">{% trans "Remember this and automatically redirect next time." %}</label>
+	</p>
+	<p>
 		<form id="lti_login_form" method="POST" action="{{ service.url }}">
 			{% for entry in parameters %}
 			<input type="hidden" name="{{ entry.0 }}" value="{{ entry.1 }}" />
@@ -63,18 +67,23 @@
 <script>
 $(function() {
 	var cookieName = "aplusexse{{ service.id }}";
+	var cookieValue = "{{ parameters_hash }}";
+	var set_cookie = function(expire_years=1) {
+		var expire = new Date();
+		expire.setFullYear(expire.getFullYear() + expire_years);
+		var path = document.location.href.split("/");
+		document.cookie = cookieName + "=" + cookieValue
+				+ ";path=/" + path[3] + "/" + path[4] + "/"
+				+ ";expires=" + expire.toGMTString();
+	};
 	var regex = new RegExp("(?:(?:^|.*;\s*)" + cookieName + "\s*\=\s*([^;]*).*$)|^.*$");
 	var val = document.cookie.replace(regex, "$1");
-	if (val == "1") {
-		$("form")[0].submit();
-	}
-	$("form").on("submit", function() {
-		var expire = new Date();
-		expire.setFullYear(expire.getFullYear() + 1);
-		var path = document.location.href.split("/");
-		document.cookie = cookieName + "=1"
-			+ ";path=/" + path[3] + "/" + path[4] + "/"
-			+ ";expires=" + expire.toGMTString();
+	var form = $("#lti_login_form");
+	if (val == cookieValue) form.submit(); /* automatically submit accepted data */
+	else set_cookie(-1); /* remove old cookie */
+	form.on("submit", function() {
+		/* on submit remember accepted state via local cookie */
+		if ($('#auto_accept').is(':checked')) set_cookie();
 	});
 });
 </script>

--- a/external_services/views.py
+++ b/external_services/views.py
@@ -50,9 +50,10 @@ class LTILoginView(CourseInstanceBaseView):
             self.request.get_host(),
             self.menu_item.label,
         )
+        self.parameters_hash = lti.get_checksum_of_parameters()
         self.parameters = lti.sign_post_parameters()
         self.site = '/'.join(self.service.url.split('/')[:3])
-        self.note("service", "parameters", "site")
+        self.note("service", "parameters_hash", "parameters", "site")
 
 
 class ListMenuItemsView(CourseInstanceBaseView):


### PR DESCRIPTION
Adds 3 custom parameters into lti launch parameters. This contain course api url, course id (for db lookup without api url parsing or request) and users api token.

In future this api token should be created per service (allows revoking access to one service).

This patch is required for mooc-jutut.