### PR TITLE
Implement Copy to clipboard button

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -246,10 +246,35 @@ $.fn.highlightCode = function(options) {
         modal.aplusModal("open");
         $.get(url, function(data) {
           if (settings.file) {
+            var content = $("<div></div>");
+
+            var hiddenTextarea = $('<textarea id="copyClipboardContent" style="display: none; width: 1px; height: 1px;"></textarea>').text(data);
+            hiddenTextarea.appendTo(content);
+            var copyButtonContent = $('<span class="glyphicon glyphicon-copy" aria-hidden="true"></span>');
+            var copyButtonText = $('<span></span>').text('Copy to clipboard');
+            var copyButton = $('<button data-clipboard-target="#copyClipboardContent" class="btn btn-xs btn-primary" id="copyButton"></button>');
+            copyButtonContent.appendTo(copyButton);
+            copyButtonText.appendTo(copyButton);
+            $('<p></p>').append(copyButton).appendTo(content);
+
+            copyButton.click(function() {
+              $("#copyClipboardContent").show();
+            });
+
+            var clipboard = new Clipboard("#copyButton");
+            clipboard.on("error", function(e) {
+                $("#copyClipboardContent").hide();
+            });
+            clipboard.on("success", function(e) {
+                $("#copyClipboardContent").hide();
+            });
+
             var text = $("<pre/>").text(data);
+            text.appendTo(content);
+
             modal.aplusModal("content", {
               title: link.text(),
-              content: text,
+              content: content,
             });
             text.highlightCode();
           } else {

--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -153,8 +153,6 @@ $.fn.highlightCode = function(options) {
   });
 };
 
-$.fn.highlightCode.counter = 0;
-
 /**
  * Handle common modal dialog.
  */

--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -101,13 +101,49 @@ $(function() {
 /**
  * Highlights code element.
  */
-$.fn.highlightCode = function(options) {
-  return this.each(function() {
 
-    hljs.highlightBlock(this);
+var copyTargetCounter = 0;
+
+$.fn.highlightCode = function(options) {
+
+  return this.each(function() {
+    var codeBlock = $(this).clone();
+    var wrapper = $('<div></div>');
+    wrapper.append(codeBlock);
+    $(this).replaceWith(wrapper);
+
+    // Use $(element).highlightCode{noCopy: true} to prevent copy button
+    if (!options || !options.noCopy) {
+      var buttonContainer = $('<p></p>').prependTo(wrapper);
+      var copyButtonContent = $('<span class="glyphicon glyphicon-copy" aria-hidden="true"></span>');
+      var copyButtonText = $('<span></span>').text('Copy to clipboard');
+      var copyButton = $('<button data-clipboard-target="#clipboard-content-' + copyTargetCounter + '" class="btn btn-xs btn-primary" id="copyButton"></button>');
+      copyButtonContent.appendTo(copyButton);
+      copyButtonText.appendTo(copyButton);
+      copyButton.appendTo(buttonContainer);
+
+      var hiddenTextarea = $('<textarea id="clipboard-content-' + copyTargetCounter + '" style="display: none; width: 1px; height: 1px;"></textarea>').text(codeBlock.text());
+      hiddenTextarea.appendTo(wrapper);
+      copyTargetCounter += 1;
+
+      // clipboard.js cannot copy from invisible elements
+      copyButton.click(function() {
+        hiddenTextarea.show();
+      });
+
+      var clipboard = new Clipboard('#copyButton');
+      clipboard.on("error", function(e) {
+          hiddenTextarea.hide();
+      });
+      clipboard.on("success", function(e) {
+          hiddenTextarea.hide();
+      });
+    }
+
+    hljs.highlightBlock(codeBlock[0]);
 
     // Add line numbers.
-    var pre = $(this);
+    var pre = $(codeBlock);
     var lines = pre.html().split(/\r\n|\r|\n/g);
     var list = $("<table/>").addClass("src");
     for (var i = 1; i <= lines.length; i++) {
@@ -116,6 +152,8 @@ $.fn.highlightCode = function(options) {
     pre.html(list);
   });
 };
+
+$.fn.highlightCode.counter = 0;
 
 /**
  * Handle common modal dialog.
@@ -246,35 +284,10 @@ $.fn.highlightCode = function(options) {
         modal.aplusModal("open");
         $.get(url, function(data) {
           if (settings.file) {
-            var content = $("<div></div>");
-
-            var hiddenTextarea = $('<textarea id="copyClipboardContent" style="display: none; width: 1px; height: 1px;"></textarea>').text(data);
-            hiddenTextarea.appendTo(content);
-            var copyButtonContent = $('<span class="glyphicon glyphicon-copy" aria-hidden="true"></span>');
-            var copyButtonText = $('<span></span>').text('Copy to clipboard');
-            var copyButton = $('<button data-clipboard-target="#copyClipboardContent" class="btn btn-xs btn-primary" id="copyButton"></button>');
-            copyButtonContent.appendTo(copyButton);
-            copyButtonText.appendTo(copyButton);
-            $('<p></p>').append(copyButton).appendTo(content);
-
-            copyButton.click(function() {
-              $("#copyClipboardContent").show();
-            });
-
-            var clipboard = new Clipboard("#copyButton");
-            clipboard.on("error", function(e) {
-                $("#copyClipboardContent").hide();
-            });
-            clipboard.on("success", function(e) {
-                $("#copyClipboardContent").hide();
-            });
-
             var text = $("<pre/>").text(data);
-            text.appendTo(content);
-
             modal.aplusModal("content", {
               title: link.text(),
-              content: content,
+              content: text,
             });
             text.highlightCode();
           } else {

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,8 @@
         <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/github.min.css" rel="stylesheet" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
 
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.12/clipboard.min.js"></script>
+
         <link rel="stylesheet" href="{% static 'css/main.css' %}" />
         <link rel="stylesheet" href="{% static 'css/submission.css' %}" />
         <script src="{% static 'js/aplus.js' %}"></script>


### PR DESCRIPTION
Allows easy copying of students' code in Inspect view.

![copy](https://cloud.githubusercontent.com/assets/2797729/20430924/e4ad8e40-ad9f-11e6-81c7-762cbbde655a.png)

The button text cannot be currently translated and this does not work with model solutions.
