### PR TITLE
Submission result filtering fixes (by score)

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -320,6 +320,12 @@ $(function() {
                 pass = false;
                 return false;
               }
+		      if (self.filters[i] && self.filters[3] !== "") {
+                if (self.filters[3] != $(this).text().toLowerCase().trim()) {
+                  pass = false;
+                  return false;
+                }
+              }
             });
             return pass;
           }).show();


### PR DESCRIPTION
This fixes a score filtering bug in aplus.js.

Filtering other fields is fine with partial match but score should be exact.

Filter scores by 0
Matches before: 0, 10, 102, 300, 50 etc.
Matches now: 0

Filter scores by 10 
Matches before: 10, 110, 710, 1000 etc.
Matches now: 10
