### PR TITLE
stripped whitespace from course configure urls

### DIFF
--- a/edit_course/operations/configure.py
+++ b/edit_course/operations/configure.py
@@ -208,6 +208,7 @@ def configure_content(instance, url):
     if not url:
         return [_("Configuration URL required.")]
     try:
+        url = url.strip()
         response = requests.get(url)
     except Exception as e:
         return [_("Request failed: {}").format(str(e))]


### PR DESCRIPTION
Since usually when you paste configure url from mooc-grader it comes with space in the end and breaks the configure phase. It has been annoying enough for me to create a simple fix, since it is less effort for the server to strip the space than me doing it manually.