### PR TITLE
Fix obsolete course configuration key

### DIFF
--- a/edit_course/operations/configure.py
+++ b/edit_course/operations/configure.py
@@ -174,8 +174,8 @@ def configure_learning_objects(category_map, module, config, parent,
             lobject.exercise_info = o["exercise_info"]
         if "model_answer" in o:
             lobject.model_answers = o["model_answer"]
-        if "template" in o:
-            lobject.templates = o["template"]
+        if "exercise_template" in o:
+            lobject.templates = o["exercise_template"]
         lobject.clean()
         lobject.save()
         seen.append(lobject.id)


### PR DESCRIPTION
The key was changed in mooc-grader in order to fix an [issue](https://github.com/Aalto-LeTech/mooc-grader/issues/18).