### PR TITLE
Cache invalidation/generation bug fix

### DIFF
--- a/lib/cached.py
+++ b/lib/cached.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.utils import timezone
 import logging
 
 
@@ -18,18 +19,45 @@ class CachedAbstract(object):
     @classmethod
     def invalidate(cls, *models, modifiers=[]):
         cache_key = cls._key(*models, modifiers=modifiers)
-        logger.debug("Invalidating cached data for {}".format(cache_key))
-        cache.delete(cache_key)
+        ts = timezone.now()
+        logger.debug("Invalidating cached data for {} with ts {}".format(cache_key, str(ts)))
+        invalidated = {
+                "invalidation_ts": ts
+                }
+        # overwrite the current cache with this invalidation timestamp
+        # this could be basically anything but ts is nice if debugging needs to be done
+        cache.set(cache_key, invalidated, 60*60)
 
     def __init__(self, *models, modifiers=[]):
         cache_key = self.__class__._key(*models, modifiers=modifiers)
         data = cache.get(cache_key)
+
+        # if invalidation_ts exists in the returned data, lets
+        # pass none to _needs_generation since its implementation
+        # depends on it. from _needs_generation's point of fiew
+        # nothing has changed
+        if data is not None and "invalidation_ts" in data:
+            data = None
+
         if self._needs_generation(data):
-            logger.debug("Generating cached data for {}".format(cache_key))
+
+            gen_start_ts = timezone.now()
+            logger.debug("Generating cached data for {} with ts {}".format(cache_key, str(gen_start_ts)))
             self.dirty = False
+
+            # before cache regeneration delete the entry
+            cache.delete(cache_key)
             data = self._generate_data(*models, data=data)
-            if not self.dirty:
-                cache.set(cache_key, data, None)
+
+            # if another process invalidated the cache during the time consuming
+            # generation cache.add() doesn't do anything
+            cache_updated = cache.add(cache_key, data, None)
+            if cache_updated:
+                logger.debug("Set newly generated data for {} with ts {}".format(cache_key, str(gen_start_ts)))
+            else:
+                logger.debug("Discarded generated data for {} with ts {}".format(cache_key, str(gen_start_ts)))
+
+        # in either case return the data
         self.data = data
 
     def _needs_generation(self, data):


### PR DESCRIPTION
This PR tries to solve the cache invalidation bug fix which happens when:

1. time consuming cache generation starts
2. during the generation the cache is invalidated from another uwsgi python process
3. when the generation ends the result is actually useless since new invalidation was done during the generation

The code should include enough comments to understand the fix. From limited local testing this seems to work. Below you can see some logs which were captured while making multiple submissions to same exercise in multiple tabs (the exercise in question took a couple of seconds to complete in grader).

Please look at the code and comment! :)

```
 ✘  ~/koodaus/work/plus-dev  ./docker-up.sh | grep "DEBUG/cached"
Starting aplus_grader_1 ... 
Starting aplus_grader_1 ... done
Starting aplus_plus_1 ... 
Starting aplus_plus_1 ... done
plus_1    | [2018-02-13 11:07:37,782: DEBUG/cached] Generating cached data for content:1 with ts 2018-02-13 09:07:37.782931+00:00
plus_1    | [2018-02-13 11:07:37,902: DEBUG/cached] Setting newly generated data for content:1 with ts 2018-02-13 09:07:37.782931+00:00
plus_1    | [2018-02-13 11:07:37,920: DEBUG/cached] Generating cached data for exercise:132,fi with ts 2018-02-13 09:07:37.920606+00:00
plus_1    | [2018-02-13 11:07:37,981: DEBUG/cached] Setting newly generated data for exercise:132,fi with ts 2018-02-13 09:07:37.920606+00:00
plus_1    | [2018-02-13 11:07:38,051: DEBUG/cached] Generating cached data for notifications:1 with ts 2018-02-13 09:07:38.051155+00:00
plus_1    | [2018-02-13 11:07:38,055: DEBUG/cached] Setting newly generated data for notifications:1 with ts 2018-02-13 09:07:38.051155+00:00
plus_1    | [2018-02-13 11:07:38,056: DEBUG/cached] Generating cached data for topmenu:1 with ts 2018-02-13 09:07:38.056317+00:00
plus_1    | [2018-02-13 11:07:38,062: DEBUG/cached] Setting newly generated data for topmenu:1 with ts 2018-02-13 09:07:38.056317+00:00
plus_1    | [2018-02-13 11:07:38,070: DEBUG/cached] Generating cached data for coursemenu:1 with ts 2018-02-13 09:07:38.070880+00:00
plus_1    | [2018-02-13 11:07:38,072: DEBUG/cached] Setting newly generated data for coursemenu:1 with ts 2018-02-13 09:07:38.070880+00:00
plus_1    | [2018-02-13 11:07:38,073: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:07:38.073441+00:00
plus_1    | [2018-02-13 11:07:38,231: DEBUG/cached] Setting newly generated data for points:1,1 with ts 2018-02-13 09:07:38.073441+00:00
plus_1    | [2018-02-13 11:07:53,862: DEBUG/cached] Invalidating cached data for points:1,1 with ts 2018-02-13 09:07:53.862193+00:00
plus_1    | [2018-02-13 11:07:53,918: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:07:53.918361+00:00
plus_1    | [2018-02-13 11:07:54,252: DEBUG/cached] Invalidating cached data for points:1,1 with ts 2018-02-13 09:07:54.251969+00:00
plus_1    | [2018-02-13 11:07:54,370: DEBUG/cached] Discarding generated data for points:1,1; gen ts: 2018-02-13 09:07:53.918361+00:00, inv ts: 2018-02-13 09:07:54.251969+00:00
plus_1    | [2018-02-13 11:07:54,378: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:07:54.378819+00:00
plus_1    | [2018-02-13 11:07:54,601: DEBUG/cached] Setting newly generated data for points:1,1; gen ts: 2018-02-13 09:07:54.378819+00:00, inv ts: 2018-02-13 09:07:54.251969+00:00
plus_1    | [2018-02-13 11:07:54,736: DEBUG/cached] Invalidating cached data for points:1,1 with ts 2018-02-13 09:07:54.736219+00:00
plus_1    | [2018-02-13 11:07:54,841: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:07:54.840982+00:00
plus_1    | [2018-02-13 11:07:55,121: DEBUG/cached] Setting newly generated data for points:1,1; gen ts: 2018-02-13 09:07:54.840982+00:00, inv ts: 2018-02-13 09:07:54.736219+00:00
plus_1    | [2018-02-13 11:07:55,839: DEBUG/cached] Invalidating cached data for points:1,1 with ts 2018-02-13 09:07:55.839880+00:00
plus_1    | [2018-02-13 11:07:55,901: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:07:55.901895+00:00
plus_1    | [2018-02-13 11:07:56,063: DEBUG/cached] Setting newly generated data for points:1,1; gen ts: 2018-02-13 09:07:55.901895+00:00, inv ts: 2018-02-13 09:07:55.839880+00:00
plus_1    | [2018-02-13 11:07:59,843: DEBUG/cached] Invalidating cached data for points:1,1 with ts 2018-02-13 09:07:59.843027+00:00
plus_1    | [2018-02-13 11:08:01,887: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:08:01.887452+00:00
plus_1    | [2018-02-13 11:08:02,103: DEBUG/cached] Setting newly generated data for points:1,1; gen ts: 2018-02-13 09:08:01.887452+00:00, inv ts: 2018-02-13 09:07:59.843027+00:00
plus_1    | [2018-02-13 11:08:18,596: DEBUG/cached] Invalidating cached data for points:1,1 with ts 2018-02-13 09:08:18.596729+00:00
plus_1    | [2018-02-13 11:08:26,534: DEBUG/cached] Generating cached data for points:1,1 with ts 2018-02-13 09:08:26.534874+00:00
plus_1    | [2018-02-13 11:08:26,710: DEBUG/cached] Setting newly generated data for points:1,1; gen ts: 2018-02-13 09:08:26.534874+00:00, inv ts: 2018-02-13 09:08:18.596729+00:00
```
 