### PR TITLE
Replace tag.text_color with tag.font_color

### DIFF
--- a/course/templates/course/staff/participants.html
+++ b/course/templates/course/staff/participants.html
@@ -24,7 +24,7 @@
         {{ external_user_label|safe }}
       </button>
       {% for tag in tags %}
-      <button class="btn btn-default btn-xs" style="background-color:{{ tag.color }};color:{{ tag.text_color }};" data-id="{{ tag.id }}">
+      <button class="btn btn-default btn-xs" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-id="{{ tag.id }}">
         <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
         {{ tag.name }}
       </button>


### PR DESCRIPTION
Fixes tag checkboxes being hard to read if the background is dark.
Turns out it was caused by a trivial typo.