### PR TITLE
Replace tag.text_color with tag.font_color in analytics

### DIFF
--- a/exercise/templates/exercise/staff/analytics.html
+++ b/exercise/templates/exercise/staff/analytics.html
@@ -49,7 +49,7 @@
       {{ external_user_label|safe }}
     </button>
     {% for tag in tags %}
-    <button class="btn btn-default btn-xs" style="background-color:{{ tag.color }};color:{{ tag.text_color }};" data-id="{{ tag.id }}">
+    <button class="btn btn-default btn-xs" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-id="{{ tag.id }}">
       <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
       {{ tag.name }}
     </button>


### PR DESCRIPTION
Found the same bug in another place. There should be no more, at least
according to grep.