### PR TITLE
Menu highlighting

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -1,13 +1,11 @@
 $(function() {
 
-    // Mark active menu based on body attribute data-view-tag.
-    var tag = $("body").attr("data-view-tag");
-    if (tag) {
-        var entries = tag.split(",");
-        for (var i = 0; i < entries.length; i++) {
-            $(".menu-" + entries[i]).addClass("active");
-        }
-    }
+    // Mark active menu item
+    $("#main-course-menu li a").each(function() {
+       if ($(this)[0].pathname === location.pathname) {
+        $(this).parent().addClass("active");
+       }
+    });
 
     $('[data-toggle="tooltip"]').tooltip();
     $('.menu-groups').aplusGroupSelect();


### PR DESCRIPTION
Highlights the correct menu entry for an open page.
Removes selection based on data-type-tag, and instead selects those menu elements whose target path matches the current URL.
Tested on the live O1 2017 course with Chrome dev tools, so it should work as intended with chapter/excersise-type menu items.