### PR TITLE
Add data-taggings to course_base

### DIFF
--- a/course/cache/students.py
+++ b/course/cache/students.py
@@ -30,6 +30,7 @@ class CachedStudents(CachedAbstract):
                 'link': participant.get_url(instance),
                 'tags': render_tags(participant, tags, instance),
                 'tag_ids': [t.id for t in tags],
+                'tag_slugs': [t.slug for t in tags],
                 'external': participant.is_external,
             })
         return {

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -15,7 +15,7 @@
 {% block title %}{{ course.name|parse_localization }} | {{ block.super }} {% endblock %}
 
 {% block content %}
-<div class="row">
+<div data-taggings="{{ taggings|join:' ' }}"  class="row">
     <div class="col-sm-2 hidden-xs">
         <nav class="course-menu" id="main-course-menu">
             <ul class="nav nav-pills nav-stacked">

--- a/course/viewbase.py
+++ b/course/viewbase.py
@@ -10,11 +10,12 @@ from authorization.permissions import ACCESS
 from exercise.cache.content import CachedContent
 from lib.viewbase import BaseTemplateView
 from userprofile.viewbase import UserProfileMixin
+from .cache.students import CachedStudents
 from .permissions import (
     CourseVisiblePermission,
     CourseModulePermission,
 )
-from .models import Course, CourseInstance, CourseModule
+from .models import Course, CourseInstance, CourseModule, UserTagging
 
 
 class CourseMixin(UserProfileMixin):
@@ -60,9 +61,14 @@ class CourseInstanceBaseMixin(object):
             self.is_assistant = self.instance.is_assistant(user)
             self.is_teacher = self.course.is_teacher(user)
             self.is_course_staff = self.is_teacher or self.is_assistant
+            self.taggings = [tag
+                             for student in CachedStudents(instance).students()
+                             if student['user_id'] == user.id
+                             for tag in student['tag_slugs']]
+
             self.note(
-                "course", "instance", "content",
-                "is_student", "is_assistant", "is_teacher", "is_course_staff",
+                "course", "instance", "content", "is_student", "is_assistant",
+                "is_teacher", "is_course_staff", "taggings",
             )
 
             # Apply course instance language.


### PR DESCRIPTION
...so that courses can customise their content based on tags.

How to use:
Suppose you have an HTML element with id 'thing-to-show' that you want
to show if the student has a tagging with the slug 'dont-show'. You should
put in your CSS file:
```css
[data-taggings~=dont-show] #thing-to-show {
    display: none;
}
```
Of course, other combinations of selectors are possible, as well as reading
the attribute from JS.