### PR TITLE
Avoid fetching unnecessary submission feedback

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -69,6 +69,7 @@ class CachedPoints(ContentMixin, CachedAbstract):
         if user.is_authenticated():
             for submission in user.userprofile.submissions\
                   .exclude_errors()\
+                  .defer('feedback')\
                   .filter(exercise__course_module__course_instance=instance):
                   #.prefetch_related("notifications"): breaks things
                 try:


### PR DESCRIPTION
When the points cache is constructed, the feedback HTML is unnecessary transferred from DB to Django.