### PR TITLE
Deviation bug fix

### DIFF
--- a/deviations/views.py
+++ b/deviations/views.py
@@ -57,6 +57,9 @@ class AddDeadlinesView(CourseInstanceMixin, BaseFormView):
                         exercise, profile, minutes, without_late_penalty)
 
             for exercise in form.cleaned_data["exercise"]:
+                if new_date:
+                    minutes = exercise.delta_in_minutes_from_closing_to_date(
+                                new_date)
                 self.add_deviation(
                     exercise, profile, minutes, without_late_penalty)
         return super().form_valid(form)


### PR DESCRIPTION
This PR fixes a bug where in the deviation view:
1. teacher chooses exercises (not modules)
2. teacher chooses new date (not minutes)
3. system incorrectly states that the student already has a deviation on that exercise

When you look at the code please note that the previous minutes value was coming from the top of the function, thus being None in the new_date scenario.