### PR TITLE
LTI exercise relative URL and missing LTI error in course import

### DIFF
--- a/edit_course/operations/configure.py
+++ b/edit_course/operations/configure.py
@@ -109,7 +109,23 @@ def configure_learning_objects(category_map, module, config, parent,
 
         if lobject_cls == LTIExercise:
             lti = LTIService.objects.filter(menu_label=str(o["lti"])).first()
-            if not lti is None:
+            if lti is None:
+                errors.append(
+                    _("The site has no configuration for the LTI service '{lti_label}' "
+                    "used by the LTI exercise '{exercise_key}'. You may have misspelled "
+                    "the value for the field 'lti' or the site administrator has not yet "
+                    "added the configuration for the LTI service. The exercise was not "
+                    "created/updated due to the error.")
+                    .format(lti_label=str(o["lti"]), exercise_key=str(o["key"]))
+                )
+                if hasattr(lobject, 'id'):
+                    # Avoid deleting LTI exercises from A+ since the LTI parameters
+                    # may have been used with an external tool.
+                    seen.append(lobject.id)
+                # The learning object can not be saved without an LTI service
+                # since the foreign key is required.
+                continue
+            else:
                 lobject.lti_service = lti
             for key in [
                 "context_id",

--- a/external_services/models.py
+++ b/external_services/models.py
@@ -83,11 +83,17 @@ class LinkService(ModelWithInheritance):
         return False
 
     def get_url(self, replace=None, kwargs={}):
+        '''Return the URL to the launch page of this service.'''
         if self.destination_region > self.DESTINATION_REGION.INTERNAL:
             return reverse('external-service-link', kwargs=kwargs)
         return self.get_final_url(replace)
 
     def get_final_url(self, replace=None):
+        '''Return the launch URL for this service.
+
+        The optional replace parameter may be a relative URL that is joined to
+        the URL path of this service. The relative URL must not include a domain.
+        '''
         url = self.url
         if replace:
             assert '://' not in replace and not replace.startswith('//'), "Replace can't include domain"

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -81,6 +81,18 @@ def has_same_domain(url1, url2):
     return uri1.netloc == uri2.netloc
 
 
+def drop_domain_from_url(url='', parsed=None):
+    """Return a URL as a string without any domain (netloc) part, i.e.,
+    with only the path, query and fragment. Supply only one of the two
+    arguments: url as a string, or if you have already parsed the URL with
+    either urllib.parse.urlparse or urllib.parse.urlsplit, then its return
+    value may be used here.
+    """
+    if url:
+        parsed = urlsplit(url)
+    return parsed._replace(scheme='', netloc='').geturl()
+
+
 FILENAME_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ._-0123456789"
 
 def safe_file_name(name):

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-19 02:44+0300\n"
+"POT-Creation-Date: 2018-09-25 17:29+0300\n"
 "PO-Revision-Date: 2018-09-19 02:21+0200\n"
 "Last-Translator: Jaakko Kantojärvi <jaakko.kantojarvi@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -991,7 +991,20 @@ msgstr "Oppimisolio vaatii kategorian."
 msgid "Unknown category '{category}'."
 msgstr "Tuntematon kategoria '{category}'."
 
-#: edit_course/operations/configure.py:200
+#: edit_course/operations/configure.py:114
+#, python-brace-format
+msgid ""
+"The site has no configuration for the LTI service '{lti_label}' used by the "
+"LTI exercise '{exercise_key}'. You may have misspelled the value for the "
+"field 'lti' or the site administrator has not yet added the configuration "
+"for the LTI service. The exercise was not created/updated due to the error."
+msgstr ""
+"Sivustolla ei ole asetuksia LTI-palvelulle '{lti_label}', jota käyttää LTI-"
+"tehtävä '{exercise_key}'. Olet mahdollisesti kirjoittanut väärin kentän "
+"'lti' arvon tai sivuston ylläpitäjä ei ole vielä lisännyt tämän LTI-palvelun "
+"asetuksia. Tehtävää ei luotu/päivitetty tämän virheen takia."
+
+#: edit_course/operations/configure.py:216
 msgid "Cannot request build log from build_log_url when it is blank."
 msgstr "Käännöslokin hakeminen ei onnistu jos build_log_url on tyhjä."
 


### PR DESCRIPTION
LTI exercises may use relative service URLs to modify the global LTI service URL and the JSON course import shows errors if the LTI service used by an exercise can not be found in A+.

**Relative service URLs in LTI exercises:**
* If an LTI exercise defines its own service URL and it is a relative URL, it is joined to the URL of the LTI service. Relative URLs with an absolute path replace the previous path completely.
* Absolute service URLs are also still supported for backwards compatibility, though their use is discouraged. The URL domain must equal the domain of the LTI service.
* If the exercise defines no service URL, the URL of the LTI service is used.

**Course import error message for missing LTI services**

LTI exercises refer to the LTI service by a label in JSON. JSON course import shows errors if the LTI service configuration is not found in A+ for the LTI exercise. Furthermore, the exercise is not updated/created.
