### PR TITLE
Enable submit buttons and reload the exercise description after finishing a submission

### DIFF
--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -851,6 +851,15 @@
 			.prop('disabled', false)
 			.removeAttr('data-aplus-submit-disabled');
 	});
+	$(document).on('hidden.bs.modal', function(e) {
+		// If the user closes the feedback modal while it is polling for
+		// the grading of the submission, the submit button remains disabled.
+		// The modal hidden event does not specify which exercise is open in
+		// the modal, so we can only enable all disabled buttons in the page.
+		$('[data-aplus-submit-disabled]')
+			.prop('disabled', false)
+			.removeAttr('data-aplus-submit-disabled');
+	});
 })(jQuery);
 
 // Construct the page chapter element.

--- a/exercise/static/exercise/poll.js
+++ b/exercise/static/exercise/poll.js
@@ -41,6 +41,7 @@
 			$.ajax(this.url, {dataType: "html"})
 				.fail(function() {
 					poller.message("error");
+					poller.ready(true);
 				})
 				.done(function(data) {
 					poller.count++;
@@ -51,6 +52,7 @@
 							poller.schedule();
 						} else {
 							poller.message("timeout");
+							poller.ready(true);
 						}
 					}
 				});
@@ -62,7 +64,8 @@
 				this.settings.poll_delays[this.count] * 1000);
 		},
 
-		ready: function() {
+		ready: function(error) {
+			// If there were no errors, the error parameter is undefined.
 			//this.element.hide();
 
 			// For active elements the element to which the poll plugin is attached remains the same, so to
@@ -72,7 +75,7 @@
 
 			var suburl = this.url.substr(0, this.url.length - "poll/".length);
 			if (this.callback) {
-				this.callback(suburl);
+				this.callback(suburl, error);
 			} else {
 				window.location = suburl;
 			}


### PR DESCRIPTION
Currently, submit buttons remain disabled in exercises embedded in chapters after the user has submitted once. The user would have to refresh the web page to be able to submit again. This PR reloads the exercise description after the submission has been graded and re-enables the submit buttons. The exercise description is reloaded because some exercises may change after submitting. Active elements are not reloaded since they contain no exercise description.

The new CustomEvents were expanded: a new event for a finished and graded submission and a new event for an aborted submission (aborted before the submission is sent anywhere).