### PR TITLE
New Shibboleth authentication

### DIFF
--- a/aplus/local_settings.example.py
+++ b/aplus/local_settings.example.py
@@ -14,6 +14,14 @@
 #    'social_django',
 #)
 
+## Shibboleth options
+#SHIBBOLETH_ENVIRONMENT_VARS = {
+#    # required for the shibboleth system:
+#    'PREFIX': 'SHIB_', # apache2: SHIB_, nginx: HTTP_SHIB_ (NOTE: client can inject HTTP_ vars!)
+#    'STUDENT_DOMAIN': 'example.com', # domain where student numbers are selected
+#    # ..more options in aplus/settings.py
+#}
+
 ## Database
 #DATABASES = {
 #    'default': {

--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -124,19 +124,38 @@ INSTALLED_APPS = (
 
 #INSTALLED_APPS += ('shibboleth_login',)
 
-# Apache module mod_uwsgi was unable to create UTF-8 environment variables.
-# Problem was avoided by URL encoding in Shibboleth:
-# <RequestMapper type="Native">
-#   <RequestMap applicationId="default" encoding="URL" />
-# </RequestMapper>
-SHIBBOLETH_VARIABLES_URL_ENCODED = True
+# Shibboleth Login configs
+#SHIBBOLETH_LOGIN = {
+#    # users, who do not exists, are created
+#    'ALLOW_CREATE_NEW_USERS': True,
+#    # if user is not found using USER_ID, then we can try with EMAIL
+#    # the search must yield only single user for it to succeed
+#    'ALLOW_SEARCH_WITH_EMAIL': False,
+#}
 
 # Fields to receive from the Shibboleth (defaults).
-#SHIB_USER_ID_KEY = 'SHIB_eppn'
-#SHIB_FIRST_NAME_KEY = 'SHIB_displayName'
-#SHIB_LAST_NAME_KEY = 'SHIB_sn'
-#SHIB_MAIL_KEY = 'SHIB_mail'
-#SHIB_STUDENT_ID_KEY = 'SHIB_schacPersonalUniqueCode'
+#SHIBBOLETH_ENVIRONMENT_VARS = {
+#    # Apache module mod_uwsgi is unable to create UTF-8 environment variables.
+#    # Problem is avoided by enabling URL encoding in Shibboleth:
+#    #   <RequestMapper type="Native">
+#    #     <RequestMap applicationId="default" encoding="URL" />
+#    #   </RequestMapper>
+#    # This is also recommended for nginx
+#    'URL_DECODE': True, # set to False, if you are passing values in UTF-8
+#    # required:
+#    'PREFIX': 'SHIB_',
+#    'STUDENT_DOMAIN': 'example.com',  # currently only student numbers from this domain are used
+#    # optional:
+#    'USER_ID': 'eppn',
+#    'FIRST_NAME': 'givenName',
+#    'LAST_NAME': 'sn',
+#    'COMMON_NAME': 'cn',        # used if first or last name is missing
+#    'FULL_NAME': 'displayName', # used if first or last name is missing
+#    'EMAIL': 'mail',
+#    'STUDENT_IDS': 'schacPersonalUniqueCode',
+#    'STUDENT_URN': ':schac:personalUniqueCode:',
+#    'STUDENT_FILTERS': {3: 'int', 2: 'studentID'},
+#}
 
 
 ## Google OAuth2 settings
@@ -399,7 +418,7 @@ update_secret_from_file(__name__, environ.get('APLUS_SECRET_KEY_FILE', 'secret_k
 # Complain if BASE_URL is not set
 try:
     if not BASE_URL:
-        raise RuntimeError('Local setting BASE_URL should be non-empty')
+        raise RuntimeError('Local setting BASE_URL can not be empty')
 except NameError as e:
     raise RuntimeError('BASE_URL must be specified in local settings') from e
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -232,14 +232,17 @@ If you are using shibboleth
  1. Shibboleth configuration in The `local_settings.py`
 
     Map your federations variables to ones used in A+.
-    Here is the default mapping, which you can override in `local_settings.py`:
+    Most of the values are common, so only defining `PREFIX` should be enough.
+    Currently, `STUDENT_DOMAIN` is a required variable, as A+ presumes student numbers to be from a single domain.
+    Rest of the options are documented in `settings.py`.
 
-        SHIB_USER_ID_KEY = 'SHIB_eppn'
-        SHIB_FIRST_NAME_KEY = 'SHIB_givenName'
-        SHIB_LAST_NAME_KEY = 'SHIB_sn'
-        SHIB_MAIL_KEY = 'SHIB_mail'
-        SHIB_STUDENT_ID_KEY = 'SHIB_schacPersonalUniqueCode'
-
+        sudo tee -a /srv/aplus/a-plus/aplus/local_settings.py << EOF
+        # Shibboleth
+        SHIBBOLETH_ENVIRONMENT_VARS = {
+            'PREFIX': 'SHIB_',
+            'STUDENT_DOMAIN': 'example.com', # XXX: change this!
+        }
+        EOF
 
  1. Reload shibboleth
 
@@ -352,17 +355,17 @@ This module uses fastcgi and shibboleth scripts to provide similar integration a
 
  1. Shibboleth configuration in The `local_settings.py`
 
-    Shibboleth under NGINX delivers shibboleth variables via the request environment,
-    thus following mapping is required.
-    If your federation uses different variables, remember to change them.
+    Map your federations variables to ones used in A+.
+    Most of the values are common, so only defining `PREFIX` should be enough.
+    Currently, `STUDENT_DOMAIN` is a required variable, as A+ presumes student numbers to be from a single domain.
+    Rest of the options are documented in `settings.py`.
 
         sudo tee -a /srv/aplus/a-plus/aplus/local_settings.py << EOF
         # Shibboleth
-        SHIB_USER_ID_KEY = 'HTTP_SHIB_EPPN'
-        SHIB_FIRST_NAME_KEY = 'HTTP_SHIB_GIVENNAME'
-        SHIB_LAST_NAME_KEY = 'HTTP_SHIB_SN'
-        SHIB_MAIL_KEY = 'HTTP_SHIB_MAIL'
-        SHIB_STUDENT_ID_KEY = 'HTTP_SHIB_SCHACPERSONALUNIQUECODE'
+        SHIBBOLETH_ENVIRONMENT_VARS = {
+            'PREFIX': 'HTTP_SHIB_',
+            'STUDENT_DOMAIN': 'example.com', # XXX: change this!
+        }
         EOF
 
  1. Reload shibboleth

--- a/doc/nginx/aplus-nginx-shib.conf
+++ b/doc/nginx/aplus-nginx-shib.conf
@@ -94,14 +94,19 @@ server {
     # authorizer so we must prevent spoofing.
     # from: https://github.com/nginx-shib/nginx-http-shibboleth/blob/master/includes/shib_clear_headers
     include shib_clear_headers;
+    # NOTE: add all fields which might be read by your A+ installation!
+    # TODO: get newer headers-more module with wildcard support!
     more_clear_input_headers
-      Shib-EPPN
-      Shib-GivenName
-      Shib-SN
-      Shib-mail
-      Shib-SchacPersonalUniqueCode
-      Persistent-Id
-      Shib-Targeted-Id;
+      shib-eppn
+      shib-givenName
+      shib-sn
+      shib-cn
+      shib-displayName
+      shib-mail
+      shib-preferredLanguage
+      shib-schacPersonalUniqueCode
+      persistent-id
+      shib-targeted-id;
 
     proxy_pass_header Server;
     include proxy_params;

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4~=4.7.1
 Django~=2.2.1
 django-bootstrap-form==3.4
 django-html5-colorfield==1.0
+django-settingsdict ~= 1.1.1
 djangorestframework~=3.9.4
 djangorestframework-csv~=2.1.0
 -e git+https://github.com/raphendyr/drf-extensions.git@reimplement_nested_routes_v4#egg=drf_extensions==0.5.1

--- a/shibboleth_login/apps.py
+++ b/shibboleth_login/apps.py
@@ -1,0 +1,70 @@
+import re
+
+from django.apps import AppConfig
+from django_settingsdict import SettingsDict
+
+
+class AplusShibbolethLoginConfig(AppConfig):
+    name = 'shibboleth_login'
+    verbose_name = 'A+ Shibboleth Login'
+
+
+def _only_prefix(value, env):
+    return re.sub(r'^((?:HTTP_)?[^_-]+[_-]).*$', r'\1', value)
+
+
+def _drop_prefix(value, env):
+    prefix = env.get('PREFIX', '')
+    if value.startswith(prefix):
+        return value[len(prefix):]
+    return value
+
+
+app_settings = SettingsDict(
+    'SHIBBOLETH_LOGIN',
+    defaults={
+        'ALLOW_CREATE_NEW_USERS': True,
+        'ALLOW_SEARCH_WITH_EMAIL': False,
+    },
+)
+
+
+env_settings = SettingsDict(
+    'SHIBBOLETH_ENVIRONMENT_VARS',
+    required=[
+        # This is typically SHIB_ for Apache 2 and
+        # HTTP_SHIB_ for nginx with http roxy
+        'PREFIX',
+        # Domain where student numbers are valid
+        # NOTE: this is temporary, until A+ supports multiple domains
+        'STUDENT_DOMAIN',
+    ],
+    defaults={
+        'USER_ID': 'eppn',
+        'FIRST_NAME': 'givenName',
+        'LAST_NAME': 'sn',
+        'COMMON_NAME': 'cn',
+        'FULL_NAME': 'displayName',
+        'EMAIL': 'mail',
+        'LANGUAGE': 'preferredLanguage',
+        # student values are based on Haka Federation
+        # https://wiki.eduuni.fi/display/CSCHAKA/Federation
+        'STUDENT_IDS': 'schacPersonalUniqueCode',
+        'STUDENT_URN': ':schac:personalUniqueCode:',
+        'STUDENT_FILTERS': {
+            2: 'studentID',
+            3: 'int',
+        },
+        'URL_DECODE': True,
+    },
+    migrate=[
+        # new name, old name, migration script
+        ('PREFIX', 'SHIB_USER_ID_KEY', _only_prefix),
+        ('USER_ID', 'SHIB_USER_ID_KEY', _drop_prefix),
+        ('FIRST_NAME', 'SHIB_FIRST_NAME_KEY', _drop_prefix),
+        ('LAST_NAME', 'SHIB_LAST_NAME_KEY', _drop_prefix),
+        ('EMAIL', 'SHIB_MAIL_KEY', _drop_prefix),
+        ('STUDENT_IDS', 'SHIB_STUDENT_ID_KEY', _drop_prefix),
+        ('URL_DECODE', 'SHIBBOLETH_VARIABLES_URL_ENCODED'),
+    ],
+)

--- a/shibboleth_login/auth_backend.py
+++ b/shibboleth_login/auth_backend.py
@@ -1,27 +1,15 @@
 import logging
 import urllib.parse
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
+from django.shortcuts import redirect
+
+from .apps import app_settings, env_settings
+from .parser import Parser
 
 
 logger = logging.getLogger('aplus.shibboleth')
-
-USER_ID_KEY = 'SHIB_USER_ID_KEY'
-FIRST_NAME_KEY = 'SHIB_FIRST_NAME_KEY'
-LAST_NAME_KEY = 'SHIB_LAST_NAME_KEY'
-MAIL_KEY = 'SHIB_MAIL_KEY'
-STUDENT_ID_KEY = 'SHIB_STUDENT_ID_KEY'
-
-# These keys may be overridden in Django settings.
-DEFAULT_KEYS = {
-    USER_ID_KEY: 'SHIB_eppn',
-    MAIL_KEY: 'SHIB_mail',
-    FIRST_NAME_KEY: 'SHIB_givenName',
-    LAST_NAME_KEY: 'SHIB_sn',
-    STUDENT_ID_KEY: 'SHIB_schacPersonalUniqueCode',
-}
 
 
 class ShibbolethAuthBackend(ModelBackend):
@@ -35,62 +23,138 @@ class ShibbolethAuthBackend(ModelBackend):
             return None
         user_save_flag = False
 
-        username = self._parse(shibd_meta, USER_ID_KEY, 30)
-        if not username:
-            logger.warning('Shibboleth login attempt without a user id.')
-            return None
-
         UserModel = get_user_model()
-        user = UserModel._default_manager.filter(username=username).first()
-        if not user:
-            logger.info('Creating a new Shibboleth authenticated user: %s', username)
-            user = UserModel._default_manager.create_user(username, '')
-            user.email = self._parse(shibd_meta, MAIL_KEY, 254) \
-                or '{:d}@localhost'.format(user.id)
+        username_field = getattr(UserModel, 'USERNAME_FIELD', 'username')
+        email_field = getattr(UserModel, 'EMAIL_FIELD', 'email')
+        username_len = UserModel._meta.get_field(username_field).max_length
+        email_len = UserModel._meta.get_field(email_field).max_length
+        first_name_len = UserModel._meta.get_field('first_name').max_length
+        last_name_len = UserModel._meta.get_field('last_name').max_length
+
+        parser = Parser(env=shibd_meta,
+                        urldecode=env_settings.URL_DECODE)
+
+        # resolve username
+        username = self._get_scoped_limited(parser, env_settings.USER_ID, username_len)
+        if not username:
+            return None
+        username = username.lower()
+
+        # resolve email
+        email = self._get_scoped_limited(parser, env_settings.EMAIL, email_len)
+        if email:
+            email = UserModel.objects.normalize_email(email)
+
+        # find user
+        try:
+            user = UserModel.objects.filter(**{username_field: username}).get()
+        except UserModel.DoesNotExist:
+            user = None
+
+        # fallback, find user with email
+        if not user and app_settings.ALLOW_SEARCH_WITH_EMAIL:
+            qs = UserModel.objects.filter(**{email_field: email})
+            if qs.count() == 1:
+                user = qs.first()
+
+        # create missing users
+        if not user and app_settings.ALLOW_CREATE_NEW_USERS:
+            logger.info('Creating a new Shibboleth authenticated user: %s <%s>',
+                username, email)
+            user = UserModel(**{
+                username_field: username,
+                email_field: email or '',
+            })
+            if not email:
+                user.save()
+                # TODO: use real domain with support for this and pseudonymized users
+                user.email = '{:d}@localhost'.format(user.id)
             user.set_unusable_password()
             user_save_flag = True
-        else:
-            email = self._parse(shibd_meta, MAIL_KEY, 254)
-            if email and email != user.email:
-                user.email = email
-                user_save_flag = True
 
-        first_name = self._parse(shibd_meta, FIRST_NAME_KEY, 30)
+        if not user:
+            return None
+
+        # update email
+        if email and email != user.email:
+            user.email = email
+            user_save_flag = True
+
+        # update first_name
+        first_name = ' '.join(parser.get_values(env_settings.FIRST_NAME, ''))[:first_name_len]
         if first_name and first_name != user.first_name:
             user.first_name = first_name
             user_save_flag = True
 
-        last_name = self._parse(shibd_meta, LAST_NAME_KEY, 30)
+        # update last_name
+        last_name = ' '.join(parser.get_values(env_settings.LAST_NAME, ''))[:last_name_len]
         if last_name and last_name != user.last_name:
             user.last_name = last_name
             user_save_flag = True
 
+        # if not first_name or last_name, fallback to cn and displayName
+        if not user.first_name or not user.last_name:
+            # best effort to find best possible name..
+            full_name = max((
+                ' '.join(parser.get_values(env_settings.FULL_NAME, '')),
+                ' '.join(parser.get_values(env_settings.COMMON_NAME, '')),
+            ), key=len)
+            first_, __, last_ = full_name.partition(' ')
+            if not user.first_name:
+                user.first_name = first_[:first_name_len]
+            if not user.last_name:
+                user.last_name = last_[:last_name_len]
+            user_save_flag = True
+
         if user_save_flag:
+            # TODO: write better error reporting, when there is a validator to raise something
+            user.full_clean()
             user.save()
 
+        # TODO: support multiple domains
         profile = user.userprofile
-        student_id = self._parse(shibd_meta, STUDENT_ID_KEY)
-        if student_id:
-            student_id = student_id.split(':')[-1][:25]
-            if student_id and student_id != profile.student_id:
-                profile.student_id = student_id
-                profile.save()
+        sid_filters = env_settings.STUDENT_FILTERS.copy()
+        # following filter drops everything else except configured domain
+        sid_filters[1] = env_settings.STUDENT_DOMAIN.lower()
+        try:
+            student_ids = parser.get_urn_values(
+                env_settings.STUDENT_URN,
+                env_settings.STUDENT_IDS,
+                filters=sid_filters)
+        except KeyError as error:
+            logger.error(error)
+            student_ids = ()
+        # example: ('123456', 'aalto.fi', 'studentID', 'int', 'mace:terena.org')
+        # -> (value (student number), the domain, id type, int|local, schema namespace)
+        student_id = next(iter(student_ids), (None,))[0]
+        if student_id and student_id != profile.student_id:
+            profile.student_id = student_id
+            profile.save()
 
         return user
 
-    def _parse(self, shibd_meta, key_name, max_length=None):
-        key = self._key(key_name)
-        if key not in shibd_meta:
-            return None
-        value = shibd_meta[key]
-        if settings.SHIBBOLETH_VARIABLES_URL_ENCODED:
-            value = urllib.parse.unquote(value)
-        if max_length:
-            return value[:max_length]
-        return value
 
-    def _key(self, name):
+    def _get_scoped_limited(self, parser, name, max_len):
         try:
-            return getattr(settings, name)
-        except AttributeError:
-            return DEFAULT_KEYS[name]
+            value = parser.get_single_value(name)
+        except KeyError:
+            logger.warning("Shibboleth login attempt without %s%s.",
+                env_settings.PREFIX, name)
+            return None
+        except ValueError as error:
+            logger.warning("Shibboleth login attempt with multiple values for %s%s: %s",
+                env_settings.PREFIX, name, str(error)[:512])
+            return None
+        if not value:
+            logger.warning("Shibboleth login attempt with empty %s%s.",
+                env_settings.PREFIX, name)
+            return None
+        if len(value) > max_len:
+            logger.warning("Shibboleth login attempt with too long %s%s (%d > %d).",
+                env_settings.PREFIX, name, len(value), max_len)
+            return None
+        if '@' not in value:
+            logger.warning("Shibboleth login attempt without domain in %s%s (%s).",
+                env_settings.PREFIX, name, value)
+            return None
+        return value

--- a/shibboleth_login/parser.py
+++ b/shibboleth_login/parser.py
@@ -1,0 +1,71 @@
+import os
+import re
+from urllib.parse import unquote
+
+
+def colons(string):
+    if string[0] != ':':
+        string = ':' + string
+    if string[-1] != ':':
+        string += ':'
+    return string
+
+
+def shib_join(*strings):
+    strings = (x.replace(r';', r'\;') for x in strings)
+    return ';'.join(strings)
+
+
+RAISE_KEYERROR = 'KeyError()'
+
+
+class Parser:
+    DELIM = re.compile(r'(?<!\\);')
+
+    def __init__(self, *, urldecode=False, filter_map=None, env=None):
+        self._urldecode = urldecode
+        if not filter_map:
+            filter_map = {}
+        self._filter_map = {colons(k): v for k, v in filter_map.items()}
+        self._env = env if env is not None else os.environ
+
+    def get_values(self, name, default=RAISE_KEYERROR):
+        try:
+            values = self._env[name.upper()]
+        except KeyError:
+            if default is RAISE_KEYERROR:
+                raise
+            return [default]
+        if self._urldecode:
+            values = unquote(values)
+        values = self.DELIM.split(values)
+        values = [x.replace(r'\;', r';') for x in values]
+        return values
+
+    def get_single_value(self, name, default=RAISE_KEYERROR):
+        values = self.get_values(name, default=default)
+        if len(values) != 1:
+            raise ValueError(
+                "Environment variable has %d values, but only one is accepted. "
+                "%s=%s" % (len(values), name, values))
+        return values[0]
+
+    def get_urn_values(self, urn, name, *, filters=None):
+        urn = colons(urn)
+        if filters is None:
+            filters = self._filter_map.get(urn)
+        fields = self.get_values(name)
+        data = []
+        for field in fields:
+            if not field:
+                continue
+            if not field.startswith('urn:'):
+                raise ValueError(
+                    "Environment variable %s values have to start with 'urn:'. "
+                    "Content is %s" % (name, fields))
+            ns, _, value = field[3:].partition(urn)
+            values = tuple(reversed(value.split(':'))) + (ns.lstrip(':'), field)
+            if filters and not all(values[i] == v for i, v in filters.items()):
+                continue
+            data.append(values)
+        return data

--- a/shibboleth_login/templates/shibboleth/meta.html
+++ b/shibboleth_login/templates/shibboleth/meta.html
@@ -1,16 +1,64 @@
 <html>
-	<head>
-		<title>Shibboleth Debug</title>
-	</head>
-	<body>
-		<p>META</p>
-		<table>
-		  {% for name,value in meta_data %}
-		  <tr>
-		  	<td>{{ name }}</td>
-		  	<td>{{ value }}</td>
-		  </tr>
-		  {% endfor %}
-		</table>
-	</body>
+<head>
+	<title>Shibboleth Debug</title>
+	<style>
+		table {
+			border-collapse: collapse;
+		}
+		table, th, td {
+			border: 1px solid black;
+			text-align: left;
+		}
+		ul {
+			list-style: square inside;
+			margin-block-start: 0;
+			margin-block-end: 0;
+			margin-inline-start: 0;
+			margin-inline-end: 0;
+			padding-inline-start: 0;
+		}
+	</style>
+</head>
+<body>
+	<p>Shibboleth variables</p>
+	<table>
+	{% for name, values in shib_meta %}
+		<tr>
+			<th>{{ name }}</th>
+			<td>
+			{% if not values %}
+			{% elif values|length == 1 %}
+				{{ values.0 }}
+			{% else %}
+				<ul>
+				{% for value in values %}
+					<li>{{ value }}</li>
+				{% endfor %}
+				</ul>
+			{% endif %}
+			</td>
+		</tr>
+	{% endfor %}
+	</table>
+
+	<p>Headers</p>
+	<table>
+	{% for name, value in headers %}
+		<tr>
+			<th>{{ name }}</th>
+			<td>{{ value }}</td>
+		</tr>
+	{% endfor %}
+	</table>
+
+	<p>request.META</p>
+	<table>
+	{% for name, value in meta %}
+		<tr>
+			<th>{{ name }}</th>
+			<td>{{ value }}</td>
+		</tr>
+	{% endfor %}
+	</table>
+</body>
 </html>

--- a/shibboleth_login/tests.py
+++ b/shibboleth_login/tests.py
@@ -1,41 +1,46 @@
-import urllib.parse
+from urllib.parse import quote
 
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
-from django.test import TestCase, modify_settings
-from django.utils import timezone
+from django.test import TestCase, modify_settings, override_settings
+
+from shibboleth_login.parser import shib_join
 
 
 DEF_SHIBD_META = {
-    'SHIB_cn': 'Teemu Teekkari',
-    'SHIB_mail': 'teemu.teekkari@aalto.fi',
-    'Shib-Authentication-Method': 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
-    'Shib-Identity-Provider': 'https://locahost/idp/shibboleth',
-    'SHIB_displayName': 'Teemudemus',
-    'Shib-AuthnContext-Class': 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
-    'SHIB_schacPersonalUniqueCode': 'urn:mace:terena.org:schac:personalUniqueCode:int:studentID:aalto.fi:123453',
-    'Shib-Session-Index': '_941d95bafed0b1787c81541e627a8c8b',
-    'SHIB_sn': 'Teekkari',
-    'SHIB_givenName': 'Teemu',
-    'Shib-Application-ID': 'default',
-    'Shib-Authentication-Instant': str(timezone.now()),
-    'Shib-Session-ID': '_92d7c6a832b5c7dafea59ea12ca1289e',
-    'SHIB_preferredLanguage': 'fi',
-    'SHIB_logouturl': 'https://localhost/idp/aalto_logout.jsp',
-    'SHIB_eppn': 'teekkarit@aalto.fi',
+    'TESTSHIB_eppn': "teekkarit@first.invalid",
+    'TESTSHIB_cn': "Temppu Ojanen Teettari", # used as fallback
+    'TESTSHIB_displayName': "Teemudemus",
+    'TESTSHIB_givenName': "Teemu",
+    'TESTSHIB_sn': "Teekkari",
+    'TESTSHIB_mail': "teemu.teekkari@first.invalid",
+    'TESTSHIB_preferredLanguage': 'en',
+    'TESTSHIB_schacPersonalUniqueCode': shib_join(
+        'urn:mace:example.invalid:schac:personalUniqueCode:int:libraryID:first.invalid:999999',
+        'urn:mace:example.invalid:schac:personalUniqueCode:int:studentID:first.invalid:123453',
+        'urn:mace:example.invalid:schac:personalUniqueCode:int:studentID:second.invalid:abcdef',
+    ),
 }
+
+ENV_VARS = {
+    'PREFIX': 'TESTSHIB_',
+    'STUDENT_DOMAIN': 'first.invalid',
+    'URL_DECODE': True,
+}
+
 
 @modify_settings(
     INSTALLED_APPS={'append': 'shibboleth_login'},
     AUTHENTICATION_BACKENDS={'append': 'shibboleth_login.auth_backend.ShibbolethAuthBackend'},
 )
+@override_settings(SHIBBOLETH_ENVIRONMENT_VARS=ENV_VARS)
 class ShibbolethTest(TestCase):
 
     def setUp(self):
         self.user = User(
-            username='meikalm8@aalto.fi',
-            email='',
+            username='meikalm8@first.invalid',
+            email='matti@second.invalid',
             first_name='Matti',
             last_name='Sukunimi',
         )
@@ -46,88 +51,264 @@ class ShibbolethTest(TestCase):
 
         self.login_url = reverse('shibboleth-login')
 
-    def test_invalid(self):
+    def test_permission_is_denied_when_user_id_is_missing(self):
         meta = DEF_SHIBD_META.copy()
-        del meta['SHIB_eppn']
+        del meta['TESTSHIB_eppn']
         response = self._get(meta)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(User.objects.count(), 1)
 
-    def test_valid_new(self):
+    def test_permission_is_denied_when_user_id_does_not_contain_domain(self):
+        meta = DEF_SHIBD_META.copy()
+        meta['TESTSHIB_eppn'] = 'invalid-non-domain'
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_permission_is_denied_when_user_id_is_way_too_long(self):
+        meta = DEF_SHIBD_META.copy()
+        meta['TESTSHIB_eppn'] = '-'.join(['invalid'] * 1000) + '@first.invalid'
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_new_user_is_create_when_there_is_valid_data(self):
         meta = DEF_SHIBD_META.copy()
         response = self._get(meta)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(User.objects.count(), 2)
-        user = User.objects.get(username='teekkarit@aalto.fi')
-        self.assertEqual(user.email, 'teemu.teekkari@aalto.fi')
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.email, 'teemu.teekkari@first.invalid')
         self.assertEqual(user.first_name, 'Teemu')
         self.assertEqual(user.last_name, 'Teekkari')
         self.assertEqual(user.userprofile.student_id, '123453')
 
-    def test_without_email(self):
+    def test_new_user_is_create_with_tuni_user_info(self):
+        """
+        Validate that shib login works with data obtained from Tampere universities
+        """
+        env_vars = ENV_VARS.copy()
         meta = DEF_SHIBD_META.copy()
-        del meta['SHIB_mail']
-        del meta['SHIB_givenName']
+        meta['TESTSHIB_schacPersonalUniqueCode'] = (
+            'urn:schac:personalUniqueCode:int:studentID:uta.fi:A11111;'
+            'urn:schac:personalUniqueCode:int:studentID:tamk.fi:222222;'
+            'urn:schac:personalUniqueCode:int:studentID:tut.fi:333333;'
+            'urn:schac:personalUniqueCode:int:studentID:uta.fi:44444'
+        )
+        tests = [
+            ('uta.fi', 'A11111'), # first instance is selected
+            ('tamk.fi', '222222'),
+            ('tut.fi', '333333'),
+        ]
+        for domain, studentid in tests:
+            with self.subTest(domain=domain, studentid=studentid):
+                env_vars['STUDENT_DOMAIN'] = domain
+                with override_settings(SHIBBOLETH_ENVIRONMENT_VARS=env_vars):
+                    response = self._get(meta)
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(User.objects.count(), 2)
+                user = User.objects.get(username='teekkarit@first.invalid')
+                self.assertEqual(user.userprofile.student_id, studentid)
+
+    def test_new_user_is_create_even_with_lowercase_meta(self):
+        meta = {k.lower(): v for k, v in DEF_SHIBD_META.items()}
         response = self._get(meta)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(User.objects.count(), 2)
-        user = User.objects.get(username='teekkarit@aalto.fi')
-        self.assertEqual(user.email, '{:d}@localhost'.format(user.id))
-        self.assertEqual(user.first_name, '')
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.email, 'teemu.teekkari@first.invalid')
+        self.assertEqual(user.first_name, 'Teemu')
         self.assertEqual(user.last_name, 'Teekkari')
         self.assertEqual(user.userprofile.student_id, '123453')
 
-    def test_without_student_id(self):
+    def test_email_is_create_when_when_email_is_missing(self):
         meta = DEF_SHIBD_META.copy()
-        del meta['SHIB_schacPersonalUniqueCode']
+        del meta['TESTSHIB_mail']
         response = self._get(meta)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(User.objects.count(), 2)
-        user = User.objects.get(username='teekkarit@aalto.fi')
-        self.assertEqual(user.email, 'teemu.teekkari@aalto.fi')
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.email, '{:d}@localhost'.format(user.id))
+        self.assertEqual(user.first_name, 'Teemu')
+        self.assertEqual(user.last_name, 'Teekkari')
+
+    def test_cn_is_used_for_first_and_last_name_when_givename_and_sn_are_missing(self):
+        meta = DEF_SHIBD_META.copy()
+        del meta['TESTSHIB_givenName']
+        del meta['TESTSHIB_sn']
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 2)
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.first_name, 'Temppu')
+        self.assertEqual(user.last_name, 'Ojanen Teettari')
+
+    def test_cn_is_used_for_first_name_when_givename_is_missing(self):
+        meta = DEF_SHIBD_META.copy()
+        del meta['TESTSHIB_givenName']
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 2)
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.first_name, 'Temppu')
+        self.assertEqual(user.last_name, 'Teekkari')
+
+    def test_displayname_is_used_for_first_name_when_givename_and_cn_are_missing(self):
+        meta = DEF_SHIBD_META.copy()
+        del meta['TESTSHIB_givenName']
+        del meta['TESTSHIB_cn']
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 2)
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.first_name, 'Teemudemus')
+        self.assertEqual(user.last_name, 'Teekkari')
+
+    def test_no_student_id_is_set_when_it_is_missing_from_shib(self):
+        meta = DEF_SHIBD_META.copy()
+        del meta['TESTSHIB_schacPersonalUniqueCode']
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 2)
+        user = User.objects.get(username='teekkarit@first.invalid')
+        self.assertEqual(user.email, 'teemu.teekkari@first.invalid')
         self.assertEqual(user.first_name, 'Teemu')
         self.assertEqual(user.last_name, 'Teekkari')
         self.assertEqual(user.userprofile.student_id, None)
 
-    def test_valid_old(self):
+    def test_second_domain_student_id_is_used_when_setting_is_changed(self):
         meta = DEF_SHIBD_META.copy()
-        meta['SHIB_eppn'] = self.user.username
-        del meta['SHIB_sn']
+        meta['TESTSHIB_eppn'] = self.user.username
+        env_vars = ENV_VARS.copy()
+        env_vars['STUDENT_DOMAIN'] = 'second.invalid'
+        with override_settings(SHIBBOLETH_ENVIRONMENT_VARS=env_vars):
+
+            response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 1)
+        user = User.objects.first()
+        self.assertEqual(user.userprofile.student_id, 'abcdef')
+
+    def test_last_name_is_not_updated_when_sn_is_missing(self):
+        meta = DEF_SHIBD_META.copy()
+        meta['TESTSHIB_eppn'] = self.user.username
+        del meta['TESTSHIB_sn']
         response = self._get(meta)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(User.objects.count(), 1)
         user = User.objects.first()
-        self.assertEqual(user.email, 'teemu.teekkari@aalto.fi')
+        self.assertEqual(user.email, 'teemu.teekkari@first.invalid')
         self.assertEqual(user.first_name, 'Teemu')
         self.assertEqual(user.last_name, 'Sukunimi')
         self.assertEqual(user.userprofile.student_id, '123453')
 
-    def test_nonascii(self):
+    def test_values_are_not_updated_when_they_are_missing(self):
         meta = DEF_SHIBD_META.copy()
-        meta['SHIB_eppn'] = self.user.username.encode('utf-8')
-        del meta['SHIB_givenName']
-        meta['SHIB_sn'] = 'Meikäläinen'
-        del meta['SHIB_schacPersonalUniqueCode']
+        meta['TESTSHIB_eppn'] = self.user.username
+        del meta['TESTSHIB_givenName']
+        del meta['TESTSHIB_sn']
+        del meta['TESTSHIB_schacPersonalUniqueCode']
         response = self._get(meta)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(User.objects.count(), 1)
         user = User.objects.first()
-        self.assertEqual(user.email, 'teemu.teekkari@aalto.fi')
+        self.assertEqual(user.email, 'teemu.teekkari@first.invalid')
         self.assertEqual(user.first_name, 'Matti')
-        self.assertEqual(user.last_name, 'Meikäläinen')
+        self.assertEqual(user.last_name, 'Sukunimi')
         self.assertEqual(user.userprofile.student_id, '000')
 
-    def test_inactive(self):
+    def test_unicode_values_are_supported_for_names(self):
+        meta = DEF_SHIBD_META.copy()
+        meta['TESTSHIB_eppn'] = self.user.username
+        meta['TESTSHIB_givenName'] = 'Mänty'
+        meta['TESTSHIB_sn'] = 'Hölmöläinen'
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 1)
+        user = User.objects.first()
+        self.assertEqual(user.email, 'teemu.teekkari@first.invalid')
+        self.assertEqual(user.first_name, 'Mänty')
+        self.assertEqual(user.last_name, 'Hölmöläinen')
+
+    @override_settings(SHIBBOLETH_LOGIN={'ALLOW_SEARCH_WITH_EMAIL': True})
+    def test_old_user_found_using_email(self):
+        meta = DEF_SHIBD_META.copy()
+        email = self.user.email
+        meta['TESTSHIB_mail'] = email
+        response = self._get(meta)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(User.objects.count(), 1)
+        user = User.objects.first()
+        self.assertEqual(user.email, email)
+        self.assertEqual(user.first_name, 'Teemu')
+        self.assertEqual(user.last_name, 'Teekkari')
+        self.assertEqual(user.userprofile.student_id, '123453')
+
+    def test_permission_is_denied_when_user_is_inactive(self):
         self.user.is_active = False
         self.user.save()
         meta = DEF_SHIBD_META.copy()
-        meta['SHIB_eppn'] = self.user.username.encode('utf-8')
+        meta['TESTSHIB_eppn'] = self.user.username
         response = self._get(meta)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(User.objects.count(), 1)
 
     def _get(self, meta):
-        if settings.SHIBBOLETH_VARIABLES_URL_ENCODED:
-            for key in meta.keys():
-                meta[key] = urllib.parse.quote(meta[key])
+        meta = {key: quote(value) for key, value in meta.items()}
         return self.client.generic('GET', self.login_url, **meta)
+
+
+
+@modify_settings(
+    INSTALLED_APPS={'append': 'shibboleth_login'},
+    AUTHENTICATION_BACKENDS={'append': 'shibboleth_login.auth_backend.ShibbolethAuthBackend'},
+)
+class ShibbolethSettingsTest(TestCase):
+
+    def test_SHIBBOLETH_VARIABLES_URL_ENCODED_is_migrated(self):
+        settings = dict(
+            SHIBBOLETH_VARIABLES_URL_ENCODED = 'test-value',
+            SHIBBOLETH_ENVIRONMENT_VARS = {
+                'STUDENT_DOMAIN': ENV_VARS['STUDENT_DOMAIN'],
+                'PREFIX': ENV_VARS['PREFIX'],
+            },
+        )
+        with override_settings(**settings):
+            from shibboleth_login.apps import env_settings
+            self.assertEqual(env_settings.URL_DECODE, 'test-value')
+
+    def test_old_settings_are_parsed_correctly(self):
+        settings = dict(
+            SHIB_USER_ID_KEY = 'RANDOM_EPPN',
+            SHIB_FIRST_NAME_KEY = 'RANDOM_GIVENNAME',
+            SHIB_LAST_NAME_KEY = 'RANDOM_SN',
+            SHIB_MAIL_KEY = 'RANDOM_MAIL',
+            SHIB_STUDENT_ID_KEY = 'RANDOM_SCHACPERSONALUNIQUECODE',
+            SHIBBOLETH_ENVIRONMENT_VARS = {'STUDENT_DOMAIN': ENV_VARS['STUDENT_DOMAIN']},
+        )
+        with override_settings(**settings):
+            from shibboleth_login.apps import env_settings
+            self.assertEqual(env_settings.PREFIX, 'RANDOM_')
+            self.assertEqual(env_settings.USER_ID, 'EPPN')
+            self.assertEqual(env_settings.FIRST_NAME, 'GIVENNAME')
+            self.assertEqual(env_settings.LAST_NAME, 'SN')
+            self.assertEqual(env_settings.EMAIL, 'MAIL')
+            self.assertEqual(env_settings.STUDENT_IDS, 'SCHACPERSONALUNIQUECODE')
+
+    def test_old_settings_with_http_prefix_are_parsed_correctly(self):
+        settings = dict(
+            SHIB_USER_ID_KEY = 'HTTP_SHIB_EPPN',
+            SHIB_FIRST_NAME_KEY = 'HTTP_SHIB_GIVENNAME',
+            SHIB_LAST_NAME_KEY = 'HTTP_SHIB_SN',
+            SHIB_MAIL_KEY = 'HTTP_SHIB_MAIL',
+            SHIB_STUDENT_ID_KEY = 'HTTP_SHIB_SCHACPERSONALUNIQUECODE',
+            SHIBBOLETH_ENVIRONMENT_VARS = {'STUDENT_DOMAIN': ENV_VARS['STUDENT_DOMAIN']},
+        )
+        with override_settings(**settings):
+            from shibboleth_login.apps import env_settings
+            self.assertEqual(env_settings.PREFIX, 'HTTP_SHIB_')
+            self.assertEqual(env_settings.USER_ID, 'EPPN')
+            self.assertEqual(env_settings.FIRST_NAME, 'GIVENNAME')
+            self.assertEqual(env_settings.LAST_NAME, 'SN')
+            self.assertEqual(env_settings.EMAIL, 'MAIL')
+            self.assertEqual(env_settings.STUDENT_IDS, 'SCHACPERSONALUNIQUECODE')


### PR DESCRIPTION
* Dictionary style settings for shibboleth configuration
* Implement a parser for shib2 encoded multivalue fields.
* Parse only a single student number, based on a config value
* Authentication backend is rewritten, but should be more robust
  and handle problems better than before.
  e.g. before, oo long input values were just cut, and thus multiple
  different inputs might have resulted same output.
  Now we raise errors instead and require someone to fix the actual
  problem.
* Better debug output.. So we can actually find out these problems :)

Note that the `SHIBBOLETH_ENVIRONMENT_VARS.STUDENT_DOMAIN` configuration variable is now required with shibboleth! Check the documentation.