### PR TITLE
Bug fix to EoC. Fix decimals and method to get filtered row count.

### DIFF
--- a/assets/js/filter.js
+++ b/assets/js/filter.js
@@ -56,7 +56,7 @@ $(function() {
             var filterRow = $('<tr class="tableexport-ignore"></tr>');
             for (var i = 0; i < columnCount; i++) {
                 this.filters.push('');
-                var filterInput = 
+                var filterInput =
                     $('<input type="text" data-column="' + i + '">')
                     .on('keyup', filterDelay).on('change', filterDelay);
 
@@ -193,7 +193,7 @@ $(function() {
                         const parsedQuery = self.filters[i][1]
                         const origQuery = self.filters[i][2];
                         const isDate = self.filters[i][3];
-                        const tdData = isDate ? 
+                        const tdData = isDate ?
                             $(this).data("datetime")
                             : $(this).text().trim();
                         if (
@@ -210,6 +210,15 @@ $(function() {
                     });
                     return pass;
                 }).show();
+
+            // Add #selected-number to e.g. span tag to get count of rows after filter
+            var visibleRows = this.element.
+                find('tbody').
+                find('tr:visible').
+                not('.no-filtering').length;
+            if ($("#selected-number").length) {
+                $("#selected-number").text(visibleRows);
+            }
         },
     });
 

--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -157,6 +157,7 @@
         dataValues.forEach(function(value) {
             sumValue += value[0];
         });
+        sumValue = Number.isInteger(sumValue) ? sumValue : sumValue.toFixed(2);
 
         // Empty data cells for total and tags in data indicators
         if (dataValues && dataValues.length > 0) {
@@ -176,7 +177,8 @@
 
         // Normal and percentage values on seperate rows in data indicators
         dataValues.forEach(function(value) {
-            normalValuesHtml += '<td class="indi-normal-val">' + value[0] + '</td>';
+            let normalValue = Number.isInteger(value[0]) ? value[0] : value[0].toFixed(2);
+            normalValuesHtml += '<td class="indi-normal-val">' + normalValue + '</td>';
             pctValuesHtml += '<td class="indi-pct-val">' + value[1].toFixed(2) + '%</td>';
         });
 
@@ -601,7 +603,11 @@
         $("#table-body").append(htmlTableIndicators);
         $("#table-body").append(htmlTablePoints);
         $(".colortag-active").css("margin-right", "5px");
-        $("#student-count").append(" (" + $(".student-id").length + " / " + _students.count + _(" students selected") + ")");
+        $("#student-count").append(
+            ' (<span id="selected-number">' + filteredStudentPool.length + '</span> / '
+            + '<span id="participants-number">'+ _students.count + '</span>'
+            + _(' students selected') + ')'
+        );
         tableExportVar.reset();
         $('#table-points').find("caption").remove(); // Remove the recreated TableExport buttons (they are already in dropdown)
         $('.filtered-table').aplusTableFilter();

--- a/exercise/templates/exercise/staff/results.html
+++ b/exercise/templates/exercise/staff/results.html
@@ -77,7 +77,7 @@
 
 		<!--Checkboxes to select extra information about data-->
 		<div style="margin: 10px;">
-			<h4 class="text-center">{% trans "Summaries" %}</h4>
+			<h4>{% trans "Summaries" %}</h4>
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Total number of submissions. Calculates all student submission counts together.' %}">
 				<input type="checkbox" class="total-subm-checkbox" value="total-subm">


### PR DESCRIPTION
Fix decimals to two in the indicators, currently there are about 10 decimals shown, it makes the table hard to read.

Also add option to filter to get the count of visible table rows with #selected-number ID. Currently the selected students / total students on top left of table is not shown.