### PR TITLE
Fix JS bug in the removal of user taggings

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.conf import settings
 from django.conf.urls import url, include
 from rest_framework_extensions.routers import ExtendedDefaultRouter
@@ -9,7 +11,16 @@ import exercise.api.csv.views
 import external_services.api.views
 
 
-api = ExtendedDefaultRouter()
+class AplusRouter(ExtendedDefaultRouter):
+    routes = copy.deepcopy(ExtendedDefaultRouter.routes)
+    # Add DELETE to list routes. Enabled if there is method `destroy_many` in the viewset.
+    # This could break if the super class definition in the framework is modified.
+    # We have to assume that the first route in routes is the list route.
+    # The framework does not map the DELETE method for it at all, so we do it here.
+    routes[0].mapping['delete'] = 'destroy_many'
+
+
+api = AplusRouter()
 
 api.register(r'users',
              userprofile.api.views.UserViewSet,

--- a/course/static/course/usertagdropdown.js
+++ b/course/static/course/usertagdropdown.js
@@ -22,7 +22,7 @@
             $container.append($elem);
         },
         function (jqXHRs, tags_xhr) { tags_xhr.done(function (data_tags) {
-          const tags = data_tags.results;
+          const tags = data_tags.results; //FIXME course tags might be paginated and this only reads the first page
           jqXHRs.forEach(function (jqXHR) {
             jqXHR.done(function (data) {
               const tag = tags.find(function (tag) {


### PR DESCRIPTION
Previously, deleting user taggings in the course participants page
could fail because the JS code did not handle paginated responses
from the API. The code retrieved all user taggings for the tag
even though it was only supposed to remove one tagging.

The commit adds a new endpoint to the API so that it is easy to
delete taggings without retrieving all taggings (which was
previously done to find out the ID of the tagging to delete).

The new JS code for the deletion may also delete multiple taggings
in a single HTTP DELETE request.