### PR TITLE
Fix chapter links with nested directories

### DIFF
--- a/lib/remote_page.py
+++ b/lib/remote_page.py
@@ -194,12 +194,14 @@ class RemotePage:
                 # If chapter is in a nested directory, folders names between
                 # the module and the chapter must be removed
                 # from the link since a-plus urls do not have them.
-                if len(element[attr_name].split('/')) > 3:
-                    path_to_module = ('/').join(element[attr_name].split('/')[0:3])+'/'
+                split_path = element[attr_name].split('/')
+                if len(split_path) > 3:
+                    path_to_module = ('/').join(split_path[0:3])+'/'
                     # Links can be written with our without the ending slash ('/')
-                    index = 1 if element[attr_name].split('/')[-1] else 2
-                    chapter_name = element[attr_name].split('/')[-index]
+                    chapter_name = '_'.join(split_path[3:])
                     element[attr_name] = path_to_module + chapter_name
+                    if element[attr_name][-1] == '_':
+                        element[attr_name] = element[attr_name][:-1]
 
             elif value and not test.match(value):
 

--- a/lib/remote_page.py
+++ b/lib/remote_page.py
@@ -191,6 +191,16 @@ class RemotePage:
                 elif not value.startswith('/'):
                     element[attr_name] = '../' + value
 
+                # If chapter is in a nested directory, folders names between
+                # the module and the chapter must be removed
+                # from the link since a-plus urls do not have them.
+                if len(element[attr_name].split('/')) > 3:
+                    path_to_module = ('/').join(element[attr_name].split('/')[0:3])+'/'
+                    # Links can be written with our without the ending slash ('/')
+                    index = 1 if element[attr_name].split('/')[-1] else 2
+                    chapter_name = element[attr_name].split('/')[-index]
+                    element[attr_name] = path_to_module + chapter_name
+
             elif value and not test.match(value):
 
                 # Custom transform for RST generated exercises.


### PR DESCRIPTION
Rst-tools write links with full directory path
`/module_name/some_folder/chapter_name`. However, in A-plus, the URL
directory is `/module_name/chapter_name`, so the folder names between must be
removed. Links can be written with or without the ending `/` so it must be checked, too.

This solution expects the URLs of the chapters to be form
`https://plus.cs.aalto.fi/course/version/module/chapter/`, and at least the courses currently in production seem to use that form.