### PR TITLE
FIX: Import a function that was already used.

### DIFF
--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -17,7 +17,7 @@ from course.models import (
     USERTAG_INTERNAL,
 )
 from deviations.models import MaxSubmissionsRuleDeviation
-from lib.helpers import settings_text
+from lib.helpers import settings_text, extract_form_errors
 from lib.viewbase import BaseRedirectView, BaseFormView, BaseView
 from notification.models import Notification
 from authorization.permissions import ACCESS


### PR DESCRIPTION
The function  `extract_form_errors` was already used in the file `staff_views.py` yet it was not imported which caused an 'undefined name' error.